### PR TITLE
NFT: fixed incorrect tokenID size

### DIFF
--- a/nft/ethereum_payment_obligation.go
+++ b/nft/ethereum_payment_obligation.go
@@ -235,7 +235,11 @@ type MintRequest struct {
 
 // NewMintRequest converts the parameters and returns a struct with needed parameter for minting
 func NewMintRequest(to common.Address, anchorID anchors.AnchorID, proofs []*proofspb.Proof, rootHash [32]byte) (*MintRequest, error) {
-	tokenID := utils.ByteSliceToBigInt(utils.RandomSlice(256))
+
+	// tokenID is uint256 in Solidity (max value is 2^256-1)
+	// tokenID has 77 digits
+	// 1 byte = 8 bits
+	tokenID := utils.ByteSliceToBigInt(utils.RandomSlice(256/8))
 	tokenURI := "http:=//www.centrifuge.io/DUMMY_URI_SERVICE"
 	proofData, err := createProofData(proofs)
 	if err != nil {

--- a/nft/ethereum_payment_obligation.go
+++ b/nft/ethereum_payment_obligation.go
@@ -236,10 +236,9 @@ type MintRequest struct {
 // NewMintRequest converts the parameters and returns a struct with needed parameter for minting
 func NewMintRequest(to common.Address, anchorID anchors.AnchorID, proofs []*proofspb.Proof, rootHash [32]byte) (*MintRequest, error) {
 
-	// tokenID is uint256 in Solidity (max value is 2^256-1)
-	// tokenID has 77 digits
-	// 1 byte = 8 bits
-	tokenID := utils.ByteSliceToBigInt(utils.RandomSlice(256/8))
+	// tokenID is uint256 in Solidity (256 bits | max value is 2^256-1)
+	// tokenID should be random 32 bytes (32 byte = 256 bits)
+	tokenID := utils.ByteSliceToBigInt(utils.RandomSlice(32))
 	tokenURI := "http:=//www.centrifuge.io/DUMMY_URI_SERVICE"
 	proofData, err := createProofData(proofs)
 	if err != nil {


### PR DESCRIPTION
The tokenID we passed to the NFT contract was too big and just cut off.


max value of a uint256 is **2^256-1** we generated randomly **2^(256*8)-1**
We are generating 256 random bytes but we actually need 256 random bits.

It is interesting that we didn't get an error from the EVM or from the bindings before sending the transaction.

Links:
https://ethereum.stackexchange.com/questions/39321/what-is-the-maximum-input-value-for-function-uint256-parameter


