### PR TITLE
use json marshaller

### DIFF
--- a/notification/notification.go
+++ b/notification/notification.go
@@ -1,12 +1,12 @@
 package notification
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/centrifuge/centrifuge-protobufs/gen/go/notification"
 	"github.com/centrifuge/go-centrifuge/errors"
 	"github.com/centrifuge/go-centrifuge/utils"
-	"github.com/golang/protobuf/jsonpb"
 	logging "github.com/ipfs/go-log"
 )
 
@@ -55,7 +55,7 @@ func (wh webhookSender) Send(notification *notificationpb.NotificationMessage) (
 		return Success, nil
 	}
 
-	payload, err := wh.constructPayload(notification)
+	payload, err := json.Marshal(notification)
 	if err != nil {
 		return Failure, err
 	}
@@ -72,14 +72,4 @@ func (wh webhookSender) Send(notification *notificationpb.NotificationMessage) (
 	log.Infof("Sent Webhook Notification with Payload [%v] to [%s]", notification, url)
 
 	return Success, nil
-}
-
-func (wh webhookSender) constructPayload(notification *notificationpb.NotificationMessage) ([]byte, error) {
-	marshaler := jsonpb.Marshaler{}
-	payload, err := marshaler.MarshalToString(notification)
-	if err != nil {
-		log.Error(err)
-		return nil, err
-	}
-	return []byte(payload), nil
 }

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -3,20 +3,23 @@
 package notification
 
 import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/centrifuge/centrifuge-protobufs/documenttypes"
-	"github.com/centrifuge/centrifuge-protobufs/gen/go/coredocument"
 	"github.com/centrifuge/centrifuge-protobufs/gen/go/notification"
 	"github.com/centrifuge/go-centrifuge/bootstrap"
 	"github.com/centrifuge/go-centrifuge/bootstrap/bootstrappers/testlogging"
 	"github.com/centrifuge/go-centrifuge/config"
 	"github.com/centrifuge/go-centrifuge/utils"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,32 +34,57 @@ func TestMain(m *testing.M) {
 	os.Exit(result)
 }
 
-func TestWebhookConstructPayload(t *testing.T) {
-	documentIdentifier := utils.RandomSlice(32)
-	coredoc := &coredocumentpb.CoreDocument{DocumentIdentifier: documentIdentifier}
-	cid := utils.RandomSlice(32)
+type mockConfig struct {
+	url string
+}
 
+func (m mockConfig) GetReceiveEventNotificationEndpoint() string {
+	return m.url
+}
+
+func TestWebhookSender_Send(t *testing.T) {
+	docID := utils.RandomSlice(32)
+	cid := utils.RandomSlice(32)
 	ts, err := ptypes.TimestampProto(time.Now().UTC())
 	assert.Nil(t, err, "Should not error out")
-	notificationMessage := &notificationpb.NotificationMessage{
-		DocumentId:   hexutil.Encode(coredoc.DocumentIdentifier),
+	var wg sync.WaitGroup
+	wg.Add(1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/webhook", func(writer http.ResponseWriter, request *http.Request) {
+		var resp struct {
+			EventType    uint32               `json:"event_type,omitempty"`
+			CentrifugeId string               `json:"centrifuge_id,omitempty"`
+			Recorded     *timestamp.Timestamp `json:"recorded,omitempty"`
+			DocumentType string               `json:"document_type,omitempty"`
+			DocumentId   string               `json:"document_id,omitempty"`
+		}
+		defer request.Body.Close()
+		data, err := ioutil.ReadAll(request.Body)
+		assert.NoError(t, err)
+
+		err = json.Unmarshal(data, &resp)
+		assert.NoError(t, err)
+		writer.Write([]byte("success"))
+		assert.Equal(t, hexutil.Encode(docID), resp.DocumentId)
+		assert.Equal(t, hexutil.Encode(cid), resp.CentrifugeId)
+		wg.Done()
+	})
+
+	server := &http.Server{Addr: ":8090", Handler: mux}
+	go server.ListenAndServe()
+	defer server.Close()
+
+	wb := NewWebhookSender(mockConfig{url: "http://localhost:8090/webhook"})
+	notif := &notificationpb.NotificationMessage{
+		DocumentId:   hexutil.Encode(docID),
 		DocumentType: documenttypes.InvoiceDataTypeUrl,
 		CentrifugeId: hexutil.Encode(cid),
 		EventType:    uint32(ReceivedPayload),
 		Recorded:     ts,
 	}
 
-	whs := webhookSender{}
-	bresult, err := whs.constructPayload(notificationMessage)
-	assert.Nil(t, err, "Should not error out")
-
-	unmarshaledNotificationMessage := &notificationpb.NotificationMessage{}
-
-	jsonpb.UnmarshalString(string(bresult), unmarshaledNotificationMessage)
-
-	assert.Equal(t, notificationMessage.Recorded, unmarshaledNotificationMessage.Recorded, "Recorder Timestamp should be equal")
-	assert.Equal(t, notificationMessage.DocumentType, unmarshaledNotificationMessage.DocumentType, "DocumentType should be equal")
-	assert.Equal(t, notificationMessage.DocumentId, unmarshaledNotificationMessage.DocumentId, "DocumentIdentifier should be equal")
-	assert.Equal(t, notificationMessage.CentrifugeId, unmarshaledNotificationMessage.CentrifugeId, "CentrifugeID should be equal")
-	assert.Equal(t, notificationMessage.EventType, unmarshaledNotificationMessage.EventType, "EventType should be equal")
+	status, err := wb.Send(notif)
+	assert.NoError(t, err)
+	assert.Equal(t, status, Success)
+	wg.Wait()
 }


### PR DESCRIPTION
Fixes #604 

1. We were using jsonpb for marshalling which will take `protobuf` struct tag. Hence the difference in the response and swagger. Since this is a webhook, we should ideally be using json.Marshaller.

2. Updated tests
