### PR TITLE
Currently godoc.org doesn't index the root directory, this fixes it

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,4 @@
+/*
+Package centrifuge is the root package for go-centrifuge. Currently its empty, but this file enables indexing the package in godoc.org.
+*/
+package centrifuge


### PR DESCRIPTION
<This is intended as a guide when describing-reviewing pull requests for go-centrifuge>
Issue Link: <Github link>
