### PR TITLE
retry when txhash not found

### DIFF
--- a/ethereum/transaction_status_task.go
+++ b/ethereum/transaction_status_task.go
@@ -150,11 +150,9 @@ func (tst *TransactionStatusTask) RunTask() (resp interface{}, err error) {
 	}()
 
 	_, isPending, err := tst.transactionByHash(ctx, common.HexToHash(tst.txHash))
-	if err != nil {
-		return nil, err
-	}
-
-	if isPending {
+	if err != nil || isPending {
+		// if the tx is not propagated, this will error out with "Not found"
+		// lets retry in this scenario as well
 		return nil, gocelery.ErrTaskRetryable
 	}
 

--- a/ethereum/transaction_status_task.go
+++ b/ethereum/transaction_status_task.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"time"
 
-	"github.com/ethereum/go-ethereum/core/types"
-
 	"github.com/centrifuge/go-centrifuge/errors"
 	"github.com/centrifuge/go-centrifuge/identity"
 	"github.com/centrifuge/go-centrifuge/queue"
 	"github.com/centrifuge/go-centrifuge/transactions"
 	"github.com/centrifuge/gocelery"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 const (
@@ -150,9 +150,17 @@ func (tst *TransactionStatusTask) RunTask() (resp interface{}, err error) {
 	}()
 
 	_, isPending, err := tst.transactionByHash(ctx, common.HexToHash(tst.txHash))
-	if err != nil || isPending {
+	if err != nil {
 		// if the tx is not propagated, this will error out with "Not found"
 		// lets retry in this scenario as well
+		if err == ethereum.NotFound {
+			err = gocelery.ErrTaskRetryable
+		}
+
+		return nil, err
+	}
+
+	if isPending {
 		return nil, gocelery.ErrTaskRetryable
 	}
 


### PR DESCRIPTION
Since infura load balances between multiple nodes, if the transaction is not propagated to the current node, it will return "not found". We should retry in this scenario instead of marking the transaction to be failed
