### PR TITLE
remove collaborators from core doc

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -64,7 +64,7 @@
   revision = "33c46d6fffa366e64fc48aff3a8a173a86eaebf6"
 
 [[projects]]
-  digest = "1:3dfab93e13cbc54458ddd94ac88c0f01eb724b28a7dd3eef5923903d1fe71cef"
+  digest = "1:94366a6a33e0dbcfa2bdf4cffe474e66b517e7863662e2fb87f28e3cd6289409"
   name = "github.com/centrifuge/centrifuge-protobufs"
   packages = [
     "documenttypes",
@@ -76,7 +76,7 @@
     "gen/go/purchaseorder",
   ]
   pruneopts = "T"
-  revision = "3e3292cf89ce246d64863fa28ac1f4cb4e57dd3e"
+  revision = "1bc057399d5d3658f8cd357b0ce22663de7c1ce8"
 
 [[projects]]
   digest = "1:6c7200e9917373ebe3c248ca47f9ee8a7924aa003c137cbfee2c763d7bc0643f"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,7 +28,7 @@ required = ["github.com/centrifuge/centrifuge-ethereum-contracts", "github.com/r
 
 [[constraint]]
   name = "github.com/centrifuge/centrifuge-protobufs"
-  revision = "3e3292cf89ce246d64863fa28ac1f4cb4e57dd3e"
+  revision = "1bc057399d5d3658f8cd357b0ce22663de7c1ce8"
 
 [[override]]
   name = "github.com/centrifuge/centrifuge-ethereum-contracts"

--- a/anchors/service_test.go
+++ b/anchors/service_test.go
@@ -45,7 +45,7 @@ func TestCorrectCommitSignatureGen(t *testing.T) {
 	correctCommitSignature := "0x4a73286521114f528967674bae4ecdc6cc94789255495429a7f58ca3ef0158ae257dd02a0ccb71d817e480d06f60f640ec021ade2ff90fe601bb7a5f4ddc569700"
 	testPrivateKey, _ := hexutil.Decode("0x17e063fa17dd8274b09c14b253697d9a20afff74ace3c04fdb1b9c814ce0ada5")
 	anchorIDTyped, _ := ToAnchorID(anchorID)
-	centIdTyped := identity.NewDIDFromByte(address)
+	centIdTyped := identity.NewDIDFromBytes(address)
 	docRootTyped, _ := ToDocumentRoot(documentRoot)
 	messageToSign := GenerateCommitHash(anchorIDTyped, centIdTyped, docRootTyped)
 	assert.Equal(t, correctCommitToSign, hexutil.Encode(messageToSign), "messageToSign not calculated correctly")

--- a/documents/coredocument.go
+++ b/documents/coredocument.go
@@ -423,9 +423,9 @@ func (cd *CoreDocument) documentTree(docType string) (tree *proofs.DocumentTree,
 
 }
 
-// GetSignCollaborators returns the collaborators excluding the filteredIDs
+// GetSignerCollaborators returns the collaborators excluding the filteredIDs
 // returns collaborators with Read_Sign permissions.
-func (cd *CoreDocument) GetSignCollaborators(filterIDs ...identity.DID) ([]identity.DID, error) {
+func (cd *CoreDocument) GetSignerCollaborators(filterIDs ...identity.DID) ([]identity.DID, error) {
 	cs, err := cd.getCollaborators(coredocumentpb.Action_ACTION_READ_SIGN)
 	if err != nil {
 		return nil, err

--- a/documents/coredocument.go
+++ b/documents/coredocument.go
@@ -14,7 +14,6 @@ import (
 	"github.com/centrifuge/go-centrifuge/utils"
 	"github.com/centrifuge/precise-proofs/proofs"
 	"github.com/centrifuge/precise-proofs/proofs/proto"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 const (
@@ -96,10 +95,6 @@ func NewCoreDocumentWithCollaborators(collaborators []string) (*CoreDocument, er
 		return nil, errors.New("failed to decode collaborators: %v", err)
 	}
 
-	for i := range ids {
-		cd.Document.Collaborators = append(cd.Document.Collaborators, ids[i][:])
-	}
-
 	cd.initReadRules(ids)
 	if err := cd.setSalts(); err != nil {
 		return nil, err
@@ -155,30 +150,30 @@ func (cd *CoreDocument) setSalts() error {
 }
 
 // PrepareNewVersion prepares the next version of the CoreDocument
-// Note: salts needs to be filled by the caller
+// if initSalts is true, salts will be generated for new version.
 func (cd *CoreDocument) PrepareNewVersion(collaborators []string, initSalts bool) (*CoreDocument, error) {
 	if len(cd.Document.DocumentRoot) != idSize {
 		return nil, errors.New("Document root is invalid")
 	}
 
-	ucs, err := fetchNewUniqueCollaborators(cd.Document.Collaborators, collaborators)
+	cs, err := identity.NewDIDsFromStrings(collaborators)
 	if err != nil {
-		return nil, errors.New("failed to fetch new collaborators: %v", err)
+		return nil, err
 	}
 
-	cs := cd.Document.Collaborators
-	for _, c := range ucs {
-		c := c
-		cs = append(cs, c[:])
+	// get all the old collaborators
+	oldCs, err := cd.GetCollaborators()
+	if err != nil {
+		return nil, err
 	}
 
+	ucs := filterCollaborators(cs, oldCs...)
 	cdp := coredocumentpb.CoreDocument{
 		DocumentIdentifier: cd.Document.DocumentIdentifier,
 		PreviousVersion:    cd.Document.CurrentVersion,
 		CurrentVersion:     cd.Document.NextVersion,
 		NextVersion:        utils.RandomSlice(32),
 		PreviousRoot:       cd.Document.DocumentRoot,
-		Collaborators:      cs,
 		Roles:              cd.Document.Roles,
 		ReadRules:          cd.Document.ReadRules,
 		Nfts:               cd.Document.Nfts,
@@ -428,53 +423,68 @@ func (cd *CoreDocument) documentTree(docType string) (tree *proofs.DocumentTree,
 
 }
 
-// GetCollaborators returns the collaborators from the role with READ_SIGN ability.
-func (cd *CoreDocument) GetCollaborators(filterIDs ...identity.DID) (ids []identity.DID, err error) {
-	exclude := make(map[string]struct{})
-	for _, id := range filterIDs {
-		exclude[id.String()] = struct{}{}
+// GetSignCollaborators returns the collaborators excluding the filteredIDs
+// returns collaborators with Read_Sign permissions.
+func (cd *CoreDocument) GetSignCollaborators(filterIDs ...identity.DID) ([]identity.DID, error) {
+	cs, err := cd.getCollaborators(coredocumentpb.Action_ACTION_READ_SIGN)
+	if err != nil {
+		return nil, err
 	}
 
-	for _, c := range cd.Document.Collaborators {
-		id := identity.NewDIDFromBytes(c)
-		if _, ok := exclude[id.String()]; ok {
-			continue
+	return filterCollaborators(cs, filterIDs...), nil
+}
+
+// GetCollaborators returns the collaborators excluding the filteredIDs
+// returns collaborators with Read and Read_Sign permissions.
+func (cd *CoreDocument) GetCollaborators(filterIDs ...identity.DID) ([]identity.DID, error) {
+	cs, err := cd.getCollaborators(coredocumentpb.Action_ACTION_READ_SIGN, coredocumentpb.Action_ACTION_READ)
+	if err != nil {
+		return nil, err
+	}
+
+	return filterCollaborators(cs, filterIDs...), nil
+}
+
+// getCollaborators returns all the collaborators who belongs to the actions passed.
+func (cd *CoreDocument) getCollaborators(actions ...coredocumentpb.Action) (ids []identity.DID, err error) {
+	findRole(cd.Document, func(_, _ int, role *coredocumentpb.Role) bool {
+		if len(role.Collaborators) < 1 {
+			return false
 		}
 
-		ids = append(ids, id)
+		for _, c := range role.Collaborators {
+			// TODO(ved): we should ideally check the address length of 20
+			// we will still keep the error return to the function so that once check is in, we don't have to refactor this function
+			ids = append(ids, identity.NewDIDFromBytes(c))
+		}
+
+		return false
+	}, actions...)
+
+	if err != nil {
+		return nil, err
 	}
 
 	return ids, nil
 }
 
-// fetchNewUniqueCollaborators returns the unique collaborators from newCollabs in reference to oldCollabs.
-func fetchNewUniqueCollaborators(oldCollabs [][]byte, newCollabs []string) (ids []identity.DID, err error) {
-	ocsm := make(map[string]struct{})
-	for _, c := range oldCollabs {
-		cs := strings.ToLower(hexutil.Encode(c))
-		ocsm[cs] = struct{}{}
+// filterCollaborators removes the filterIDs if any from cs and returns the result
+func filterCollaborators(cs []identity.DID, filterIDs ...identity.DID) (filteredIDs []identity.DID) {
+	filter := make(map[string]struct{})
+	for _, c := range filterIDs {
+		cs := strings.ToLower(c.String())
+		filter[cs] = struct{}{}
 	}
 
-	var uc []string
-	for _, c := range newCollabs {
-		cs := strings.ToLower(c)
-		if _, ok := ocsm[cs]; ok {
+	for _, id := range cs {
+		if _, ok := filter[strings.ToLower(id.String())]; ok {
 			continue
 		}
 
-		uc = append(uc, c)
+		filteredIDs = append(filteredIDs, id)
 	}
 
-	for _, c := range uc {
-		id, err := identity.NewDIDFromString(c)
-		if err != nil {
-			return nil, err
-		}
-
-		ids = append(ids, id)
-	}
-
-	return ids, nil
+	return filteredIDs
 }
 
 // CalculateDocumentRoot calculates the Document root of the core Document.

--- a/documents/coredocument_test.go
+++ b/documents/coredocument_test.go
@@ -7,19 +7,20 @@ import (
 	"os"
 	"testing"
 
-	"github.com/centrifuge/go-centrifuge/testingutils/identity"
-
 	"github.com/centrifuge/centrifuge-protobufs/documenttypes"
+	"github.com/centrifuge/centrifuge-protobufs/gen/go/coredocument"
 	"github.com/centrifuge/go-centrifuge/anchors"
 	"github.com/centrifuge/go-centrifuge/bootstrap"
 	"github.com/centrifuge/go-centrifuge/bootstrap/bootstrappers/testlogging"
 	"github.com/centrifuge/go-centrifuge/config"
 	"github.com/centrifuge/go-centrifuge/config/configstore"
+	"github.com/centrifuge/go-centrifuge/errors"
 	"github.com/centrifuge/go-centrifuge/ethereum"
 	"github.com/centrifuge/go-centrifuge/identity"
 	"github.com/centrifuge/go-centrifuge/queue"
 	"github.com/centrifuge/go-centrifuge/storage/leveldb"
 	"github.com/centrifuge/go-centrifuge/testingutils/commons"
+	"github.com/centrifuge/go-centrifuge/testingutils/identity"
 	"github.com/centrifuge/go-centrifuge/transactions/txv1"
 	"github.com/centrifuge/go-centrifuge/utils"
 	"github.com/centrifuge/precise-proofs/proofs"
@@ -68,49 +69,41 @@ func Test_fetchUniqueCollaborators(t *testing.T) {
 	o2 := testingidentity.GenerateRandomDID()
 	n1 := testingidentity.GenerateRandomDID()
 	tests := []struct {
-		old    [][]byte
-		new    []string
+		old    []identity.DID
+		new    []identity.DID
 		result []identity.DID
-		err    bool
 	}{
+		// when old cs are nil
 		{
-			new:    []string{n1.String()},
-			result: []identity.DID{n1},
+			new: []identity.DID{n1},
 		},
 
 		{
-			old:    [][]byte{o1[:]},
-			new:    []string{n1.String()},
-			result: []identity.DID{n1},
+			old:    []identity.DID{o1, o2},
+			result: []identity.DID{o1, o2},
 		},
 
 		{
-			old: [][]byte{o1[:], n1[:]},
-			new: []string{n1.String()},
+			old:    []identity.DID{o1},
+			new:    []identity.DID{n1},
+			result: []identity.DID{o1},
 		},
 
 		{
-			old: [][]byte{o1[:], o2[:]},
+			old:    []identity.DID{o1, n1},
+			new:    []identity.DID{n1},
+			result: []identity.DID{o1},
 		},
 
-		// new collaborator with wrong format
 		{
-			old: [][]byte{o1[:], o2[:]},
-			new: []string{"0x0102030405"},
-			err: true,
+			old:    []identity.DID{o1, n1},
+			new:    []identity.DID{o2},
+			result: []identity.DID{o1, n1},
 		},
 	}
 
 	for _, c := range tests {
-		uc, err := fetchNewUniqueCollaborators(c.old, c.new)
-		if err != nil {
-			if c.err {
-				continue
-			}
-
-			t.Fatal(err)
-		}
-
+		uc := filterCollaborators(c.old, c.new...)
 		assert.Equal(t, c.result, uc)
 	}
 }
@@ -118,32 +111,42 @@ func Test_fetchUniqueCollaborators(t *testing.T) {
 func TestCoreDocument_PrepareNewVersion(t *testing.T) {
 	cd := newCoreDocument()
 
-	//collaborators need to be hex string
-	collabs := []string{"some ID"}
-	ncd, err := cd.PrepareNewVersion(collabs, false)
-	assert.Error(t, err)
-	assert.Nil(t, ncd)
-
 	// missing DocumentRoot
 	c1 := testingidentity.GenerateRandomDID()
 	c2 := testingidentity.GenerateRandomDID()
 	c := []string{c1.String(), c2.String()}
-	ncd, err = cd.PrepareNewVersion(c, false)
+	ncd, err := cd.PrepareNewVersion(c, false)
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Document root is invalid")
+	assert.Nil(t, ncd)
+
+	//collaborators need to be hex string
+	cd.Document.DocumentRoot = utils.RandomSlice(32)
+	collabs := []string{"some ID"}
+	ncd, err = cd.PrepareNewVersion(collabs, false)
+	assert.Error(t, err)
+	assert.True(t, errors.IsOfType(identity.ErrMalformedAddress, err))
 	assert.Nil(t, ncd)
 
 	// successful preparation of new version upon addition of DocumentRoot
-	cd.Document.DocumentRoot = utils.RandomSlice(32)
 	ncd, err = cd.PrepareNewVersion(c, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, ncd)
-	assert.Len(t, ncd.Document.Collaborators, 2)
+	cs, err := ncd.GetCollaborators()
+	assert.NoError(t, err)
+	assert.Len(t, cs, 2)
+	assert.Contains(t, cs, c1)
+	assert.Contains(t, cs, c2)
 	assert.Nil(t, ncd.Document.CoredocumentSalts)
 
 	ncd, err = cd.PrepareNewVersion(c, true)
 	assert.NoError(t, err)
 	assert.NotNil(t, ncd)
-	assert.Len(t, ncd.Document.Collaborators, 2)
+	cs, err = ncd.GetCollaborators()
+	assert.NoError(t, err)
+	assert.Len(t, cs, 2)
+	assert.Contains(t, cs, c1)
+	assert.Contains(t, cs, c2)
 	assert.NotNil(t, ncd.Document.CoredocumentSalts)
 
 	assert.Equal(t, cd.Document.NextVersion, ncd.Document.CurrentVersion)
@@ -236,7 +239,6 @@ func TestCoreDocument_GenerateProofs(t *testing.T) {
 
 	cd := newCoreDocument()
 	cd.Document.EmbeddedData = docAny
-	cd.Document.Collaborators = [][]byte{utils.RandomSlice(32), utils.RandomSlice(32)}
 	assert.NoError(t, cd.setSalts())
 	cd.Document.DataRoot = testTree.RootHash()
 	_, err = cd.CalculateSigningRoot(documenttypes.InvoiceDataTypeUrl)
@@ -267,7 +269,7 @@ func TestCoreDocument_GenerateProofs(t *testing.T) {
 			3,
 		},
 		{
-			CDTreePrefix + ".collaborators[0]",
+			CDTreePrefix + ".next_version",
 			true,
 			6,
 		},
@@ -305,4 +307,100 @@ func TestCoreDocument_setSalts(t *testing.T) {
 	salts := cd.Document.CoredocumentSalts
 	assert.Nil(t, cd.setSalts())
 	assert.Equal(t, salts, cd.Document.CoredocumentSalts)
+}
+
+func TestCoreDocument_getCollaborators(t *testing.T) {
+	id1 := testingidentity.GenerateRandomDID()
+	id2 := testingidentity.GenerateRandomDID()
+	ids := []string{id1.String()}
+	cd, err := NewCoreDocumentWithCollaborators(ids)
+	assert.NoError(t, err)
+	cs, err := cd.getCollaborators(coredocumentpb.Action_ACTION_READ_SIGN)
+	assert.NoError(t, err)
+	assert.Len(t, cs, 1)
+	assert.Equal(t, cs[0], id1)
+
+	cs, err = cd.getCollaborators(coredocumentpb.Action_ACTION_READ)
+	assert.NoError(t, err)
+	assert.Len(t, cs, 0)
+
+	role := new(coredocumentpb.Role)
+	role.RoleKey = utils.RandomSlice(32)
+	role.Collaborators = append(role.Collaborators, id2[:])
+	cd.addNewRule(role, coredocumentpb.Action_ACTION_READ)
+
+	cs, err = cd.getCollaborators(coredocumentpb.Action_ACTION_READ)
+	assert.NoError(t, err)
+	assert.Len(t, cs, 1)
+	assert.Equal(t, cs[0], id2)
+
+	cs, err = cd.getCollaborators(coredocumentpb.Action_ACTION_READ, coredocumentpb.Action_ACTION_READ_SIGN)
+	assert.NoError(t, err)
+	assert.Len(t, cs, 2)
+	assert.Contains(t, cs, id1)
+	assert.Contains(t, cs, id2)
+}
+
+func TestCoreDocument_GetCollaborators(t *testing.T) {
+	id1 := testingidentity.GenerateRandomDID()
+	id2 := testingidentity.GenerateRandomDID()
+	ids := []string{id1.String()}
+	cd, err := NewCoreDocumentWithCollaborators(ids)
+	assert.NoError(t, err)
+	cs, err := cd.GetCollaborators()
+	assert.NoError(t, err)
+	assert.Len(t, cs, 1)
+	assert.Equal(t, cs[0], id1)
+
+	cs, err = cd.GetCollaborators(id1)
+	assert.NoError(t, err)
+	assert.Len(t, cs, 0)
+
+	role := new(coredocumentpb.Role)
+	role.RoleKey = utils.RandomSlice(32)
+	role.Collaborators = append(role.Collaborators, id2[:])
+	cd.addNewRule(role, coredocumentpb.Action_ACTION_READ)
+
+	cs, err = cd.GetCollaborators()
+	assert.NoError(t, err)
+	assert.Len(t, cs, 2)
+	assert.Contains(t, cs, id1)
+	assert.Contains(t, cs, id2)
+
+	cs, err = cd.GetCollaborators(id2)
+	assert.NoError(t, err)
+	assert.Len(t, cs, 1)
+	assert.Contains(t, cs, id1)
+}
+
+func TestCoreDocument_GetSignCollaborators(t *testing.T) {
+	id1 := testingidentity.GenerateRandomDID()
+	id2 := testingidentity.GenerateRandomDID()
+	ids := []string{id1.String()}
+	cd, err := NewCoreDocumentWithCollaborators(ids)
+	assert.NoError(t, err)
+	cs, err := cd.GetSignCollaborators()
+	assert.NoError(t, err)
+	assert.Len(t, cs, 1)
+	assert.Equal(t, cs[0], id1)
+
+	cs, err = cd.GetSignCollaborators(id1)
+	assert.NoError(t, err)
+	assert.Len(t, cs, 0)
+
+	role := new(coredocumentpb.Role)
+	role.RoleKey = utils.RandomSlice(32)
+	role.Collaborators = append(role.Collaborators, id2[:])
+	cd.addNewRule(role, coredocumentpb.Action_ACTION_READ)
+
+	cs, err = cd.GetSignCollaborators()
+	assert.NoError(t, err)
+	assert.Len(t, cs, 1)
+	assert.Contains(t, cs, id1)
+	assert.NotContains(t, cs, id2)
+
+	cs, err = cd.GetSignCollaborators(id2)
+	assert.NoError(t, err)
+	assert.Len(t, cs, 1)
+	assert.Contains(t, cs, id1)
 }

--- a/documents/coredocument_test.go
+++ b/documents/coredocument_test.go
@@ -324,8 +324,7 @@ func TestCoreDocument_getCollaborators(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, cs, 0)
 
-	role := new(coredocumentpb.Role)
-	role.RoleKey = utils.RandomSlice(32)
+	role := newRole()
 	role.Collaborators = append(role.Collaborators, id2[:])
 	cd.addNewRule(role, coredocumentpb.Action_ACTION_READ)
 
@@ -356,8 +355,7 @@ func TestCoreDocument_GetCollaborators(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, cs, 0)
 
-	role := new(coredocumentpb.Role)
-	role.RoleKey = utils.RandomSlice(32)
+	role := newRole()
 	role.Collaborators = append(role.Collaborators, id2[:])
 	cd.addNewRule(role, coredocumentpb.Action_ACTION_READ)
 
@@ -379,27 +377,26 @@ func TestCoreDocument_GetSignCollaborators(t *testing.T) {
 	ids := []string{id1.String()}
 	cd, err := NewCoreDocumentWithCollaborators(ids)
 	assert.NoError(t, err)
-	cs, err := cd.GetSignCollaborators()
+	cs, err := cd.GetSignerCollaborators()
 	assert.NoError(t, err)
 	assert.Len(t, cs, 1)
 	assert.Equal(t, cs[0], id1)
 
-	cs, err = cd.GetSignCollaborators(id1)
+	cs, err = cd.GetSignerCollaborators(id1)
 	assert.NoError(t, err)
 	assert.Len(t, cs, 0)
 
-	role := new(coredocumentpb.Role)
-	role.RoleKey = utils.RandomSlice(32)
+	role := newRole()
 	role.Collaborators = append(role.Collaborators, id2[:])
 	cd.addNewRule(role, coredocumentpb.Action_ACTION_READ)
 
-	cs, err = cd.GetSignCollaborators()
+	cs, err = cd.GetSignerCollaborators()
 	assert.NoError(t, err)
 	assert.Len(t, cs, 1)
 	assert.Contains(t, cs, id1)
 	assert.NotContains(t, cs, id2)
 
-	cs, err = cd.GetSignCollaborators(id2)
+	cs, err = cd.GetSignerCollaborators(id2)
 	assert.NoError(t, err)
 	assert.Len(t, cs, 1)
 	assert.Contains(t, cs, id1)

--- a/documents/invoice/model_test.go
+++ b/documents/invoice/model_test.go
@@ -4,6 +4,7 @@ package invoice
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"testing"
 
@@ -40,6 +41,7 @@ import (
 var ctx = map[string]interface{}{}
 var cfg config.Configuration
 var configService config.Service
+var defaultDID = testingidentity.GenerateRandomDID()
 
 func TestMain(m *testing.M) {
 	ethClient := &testingcommons.MockEthClient{}
@@ -228,10 +230,12 @@ func TestInvoiceModel_calculateDataRoot(t *testing.T) {
 	assert.NotNil(t, m.InvoiceSalts, "salts must be created")
 }
 
-func TestInvoice_GenerateProofs(t *testing.T) {
+func TestInvoice_CreateProofs(t *testing.T) {
 	i, err := createInvoice(t)
 	assert.Nil(t, err)
-	proof, err := i.CreateProofs([]string{"invoice.invoice_number", documents.CDTreePrefix + ".next_version", documents.CDTreePrefix + ".document_type"})
+	rk := i.Document.Roles[0].RoleKey
+	pf := fmt.Sprintf(documents.CDTreePrefix+".roles[%s].collaborators[0]", hexutil.Encode(rk))
+	proof, err := i.CreateProofs([]string{"invoice.invoice_number", pf, documents.CDTreePrefix + ".document_type"})
 	assert.Nil(t, err)
 	assert.NotNil(t, proof)
 	tree, err := i.CoreDocument.DocumentRootTree()
@@ -242,13 +246,14 @@ func TestInvoice_GenerateProofs(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, valid)
 
-	// Validate next_version
+	// Validate roles
 	valid, err = tree.ValidateProof(proof[1])
 	assert.Nil(t, err)
 	assert.True(t, valid)
 
 	// Validate []byte value
-	assert.Equal(t, i.NextVersion(), proof[1].Value)
+	acc := identity.NewDIDFromBytes(proof[1].Value)
+	assert.True(t, i.AccountCanRead(acc))
 
 	// Validate document_type
 	valid, err = tree.ValidateProof(proof[2])
@@ -280,7 +285,7 @@ func TestInvoiceModel_getDocumentDataTree(t *testing.T) {
 
 func createInvoice(t *testing.T) (*Invoice, error) {
 	i := new(Invoice)
-	err := i.InitInvoiceInput(testingdocuments.CreateInvoicePayload(), "0xBAEb33a61f05e6F269f1c4b4CFF91A901B54DaF7")
+	err := i.InitInvoiceInput(testingdocuments.CreateInvoicePayload(), defaultDID.String())
 	assert.NoError(t, err)
 	_, err = i.CalculateDataRoot()
 	assert.NoError(t, err)

--- a/documents/invoice/model_test.go
+++ b/documents/invoice/model_test.go
@@ -231,7 +231,7 @@ func TestInvoiceModel_calculateDataRoot(t *testing.T) {
 func TestInvoice_GenerateProofs(t *testing.T) {
 	i, err := createInvoice(t)
 	assert.Nil(t, err)
-	proof, err := i.CreateProofs([]string{"invoice.invoice_number", documents.CDTreePrefix + ".collaborators[0]", documents.CDTreePrefix + ".document_type"})
+	proof, err := i.CreateProofs([]string{"invoice.invoice_number", documents.CDTreePrefix + ".next_version", documents.CDTreePrefix + ".document_type"})
 	assert.Nil(t, err)
 	assert.NotNil(t, proof)
 	tree, err := i.CoreDocument.DocumentRootTree()
@@ -242,14 +242,13 @@ func TestInvoice_GenerateProofs(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, valid)
 
-	// Validate collaborators[0]
+	// Validate next_version
 	valid, err = tree.ValidateProof(proof[1])
 	assert.Nil(t, err)
 	assert.True(t, valid)
 
 	// Validate []byte value
-	id := identity.NewDIDFromBytes(proof[1].Value)
-	assert.True(t, i.CoreDocument.AccountCanRead(id))
+	assert.Equal(t, i.NextVersion(), proof[1].Value)
 
 	// Validate document_type
 	valid, err = tree.ValidateProof(proof[2])

--- a/documents/model.go
+++ b/documents/model.go
@@ -76,8 +76,8 @@ type Model interface {
 	// Note: returns all the collaborators with Read and Read_Sign permission
 	GetCollaborators(filterIDs ...identity.DID) ([]identity.DID, error)
 
-	// GetSignCollaborators works like GetCollaborators except it returns only those with Read_Sign permission.
-	GetSignCollaborators(filterIDs ...identity.DID) ([]identity.DID, error)
+	// GetSignerCollaborators works like GetCollaborators except it returns only those with Read_Sign permission.
+	GetSignerCollaborators(filterIDs ...identity.DID) ([]identity.DID, error)
 
 	// AccountCanRead returns true if the account can read the document
 	AccountCanRead(account identity.DID) bool

--- a/documents/model.go
+++ b/documents/model.go
@@ -73,7 +73,11 @@ type Model interface {
 
 	// GetCollaborators returns the collaborators of this Document.
 	// filter ids should not be returned
+	// Note: returns all the collaborators with Read and Read_Sign permission
 	GetCollaborators(filterIDs ...identity.DID) ([]identity.DID, error)
+
+	// GetSignCollaborators works like GetCollaborators except it returns only those with Read_Sign permission.
+	GetSignCollaborators(filterIDs ...identity.DID) ([]identity.DID, error)
 
 	// AccountCanRead returns true if the account can read the document
 	AccountCanRead(account identity.DID) bool

--- a/documents/processor.go
+++ b/documents/processor.go
@@ -177,7 +177,7 @@ func (dp defaultProcessor) SendDocument(ctx context.Context, model Model) error 
 		return err
 	}
 
-	cs, err := model.GetSignCollaborators(self.ID)
+	cs, err := model.GetSignerCollaborators(self.ID)
 	if err != nil {
 		return errors.New("get external collaborators failed: %v", err)
 	}

--- a/documents/processor.go
+++ b/documents/processor.go
@@ -177,7 +177,7 @@ func (dp defaultProcessor) SendDocument(ctx context.Context, model Model) error 
 		return err
 	}
 
-	cs, err := model.GetCollaborators(self.ID)
+	cs, err := model.GetSignCollaborators(self.ID)
 	if err != nil {
 		return errors.New("get external collaborators failed: %v", err)
 	}

--- a/documents/processor_test.go
+++ b/documents/processor_test.go
@@ -96,6 +96,12 @@ func (m *mockModel) GetCollaborators(filterIDs ...identity.DID) ([]identity.DID,
 	return cids, args.Error(1)
 }
 
+func (m *mockModel) GetSignCollaborators(filterIDs ...identity.DID) ([]identity.DID, error) {
+	args := m.Called(filterIDs)
+	cids, _ := args.Get(0).([]identity.DID)
+	return cids, args.Error(1)
+}
+
 func (m *mockModel) PackCoreDocument() (coredocumentpb.CoreDocument, error) {
 	args := m.Called()
 	cd, _ := args.Get(0).(coredocumentpb.CoreDocument)
@@ -390,7 +396,7 @@ func TestDefaultProcessor_SendDocument(t *testing.T) {
 	model.On("CalculateSigningRoot").Return(sr, nil)
 	model.On("Signatures").Return()
 	model.On("CalculateDocumentRoot").Return(dr[:], nil)
-	model.On("GetCollaborators", mock.Anything).Return(nil, errors.New("error")).Once()
+	model.On("GetSignCollaborators", mock.Anything).Return(nil, errors.New("error")).Once()
 	model.sigs = append(model.sigs, sig)
 	srv = &testingcommons.MockIdentityService{}
 	srv.On("ValidateSignature", sig, sr).Return(nil).Once()
@@ -412,7 +418,7 @@ func TestDefaultProcessor_SendDocument(t *testing.T) {
 	model.On("CalculateSigningRoot").Return(sr, nil)
 	model.On("Signatures").Return()
 	model.On("CalculateDocumentRoot").Return(dr[:], nil)
-	model.On("GetCollaborators", mock.Anything).Return([]identity.DID{testingidentity.GenerateRandomDID()}, nil).Once()
+	model.On("GetSignCollaborators", mock.Anything).Return([]identity.DID{testingidentity.GenerateRandomDID()}, nil).Once()
 	model.On("PackCoreDocument").Return(nil, errors.New("error")).Once()
 	model.sigs = append(model.sigs, sig)
 	srv = &testingcommons.MockIdentityService{}
@@ -437,7 +443,7 @@ func TestDefaultProcessor_SendDocument(t *testing.T) {
 	model.On("CalculateSigningRoot").Return(sr, nil)
 	model.On("Signatures").Return()
 	model.On("CalculateDocumentRoot").Return(dr[:], nil)
-	model.On("GetCollaborators", mock.Anything).Return([]identity.DID{did}, nil).Once()
+	model.On("GetSignCollaborators", mock.Anything).Return([]identity.DID{did}, nil).Once()
 	model.On("PackCoreDocument").Return(cd, nil).Once()
 	model.sigs = append(model.sigs, sig)
 	srv = &testingcommons.MockIdentityService{}
@@ -464,7 +470,7 @@ func TestDefaultProcessor_SendDocument(t *testing.T) {
 	model.On("CalculateSigningRoot").Return(sr, nil)
 	model.On("Signatures").Return()
 	model.On("CalculateDocumentRoot").Return(dr[:], nil)
-	model.On("GetCollaborators", mock.Anything).Return([]identity.DID{did}, nil).Once()
+	model.On("GetSignCollaborators", mock.Anything).Return([]identity.DID{did}, nil).Once()
 	model.On("PackCoreDocument").Return(cd, nil).Once()
 	model.sigs = append(model.sigs, sig)
 	srv = &testingcommons.MockIdentityService{}

--- a/documents/processor_test.go
+++ b/documents/processor_test.go
@@ -96,7 +96,7 @@ func (m *mockModel) GetCollaborators(filterIDs ...identity.DID) ([]identity.DID,
 	return cids, args.Error(1)
 }
 
-func (m *mockModel) GetSignCollaborators(filterIDs ...identity.DID) ([]identity.DID, error) {
+func (m *mockModel) GetSignerCollaborators(filterIDs ...identity.DID) ([]identity.DID, error) {
 	args := m.Called(filterIDs)
 	cids, _ := args.Get(0).([]identity.DID)
 	return cids, args.Error(1)
@@ -396,7 +396,7 @@ func TestDefaultProcessor_SendDocument(t *testing.T) {
 	model.On("CalculateSigningRoot").Return(sr, nil)
 	model.On("Signatures").Return()
 	model.On("CalculateDocumentRoot").Return(dr[:], nil)
-	model.On("GetSignCollaborators", mock.Anything).Return(nil, errors.New("error")).Once()
+	model.On("GetSignerCollaborators", mock.Anything).Return(nil, errors.New("error")).Once()
 	model.sigs = append(model.sigs, sig)
 	srv = &testingcommons.MockIdentityService{}
 	srv.On("ValidateSignature", sig, sr).Return(nil).Once()
@@ -418,7 +418,7 @@ func TestDefaultProcessor_SendDocument(t *testing.T) {
 	model.On("CalculateSigningRoot").Return(sr, nil)
 	model.On("Signatures").Return()
 	model.On("CalculateDocumentRoot").Return(dr[:], nil)
-	model.On("GetSignCollaborators", mock.Anything).Return([]identity.DID{testingidentity.GenerateRandomDID()}, nil).Once()
+	model.On("GetSignerCollaborators", mock.Anything).Return([]identity.DID{testingidentity.GenerateRandomDID()}, nil).Once()
 	model.On("PackCoreDocument").Return(nil, errors.New("error")).Once()
 	model.sigs = append(model.sigs, sig)
 	srv = &testingcommons.MockIdentityService{}
@@ -443,7 +443,7 @@ func TestDefaultProcessor_SendDocument(t *testing.T) {
 	model.On("CalculateSigningRoot").Return(sr, nil)
 	model.On("Signatures").Return()
 	model.On("CalculateDocumentRoot").Return(dr[:], nil)
-	model.On("GetSignCollaborators", mock.Anything).Return([]identity.DID{did}, nil).Once()
+	model.On("GetSignerCollaborators", mock.Anything).Return([]identity.DID{did}, nil).Once()
 	model.On("PackCoreDocument").Return(cd, nil).Once()
 	model.sigs = append(model.sigs, sig)
 	srv = &testingcommons.MockIdentityService{}
@@ -470,7 +470,7 @@ func TestDefaultProcessor_SendDocument(t *testing.T) {
 	model.On("CalculateSigningRoot").Return(sr, nil)
 	model.On("Signatures").Return()
 	model.On("CalculateDocumentRoot").Return(dr[:], nil)
-	model.On("GetSignCollaborators", mock.Anything).Return([]identity.DID{did}, nil).Once()
+	model.On("GetSignerCollaborators", mock.Anything).Return([]identity.DID{did}, nil).Once()
 	model.On("PackCoreDocument").Return(cd, nil).Once()
 	model.sigs = append(model.sigs, sig)
 	srv = &testingcommons.MockIdentityService{}

--- a/documents/purchaseorder/model_test.go
+++ b/documents/purchaseorder/model_test.go
@@ -4,6 +4,7 @@ package purchaseorder
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"testing"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/centrifuge/go-centrifuge/testingutils/commons"
 	"github.com/centrifuge/go-centrifuge/testingutils/config"
 	"github.com/centrifuge/go-centrifuge/testingutils/documents"
+	"github.com/centrifuge/go-centrifuge/testingutils/identity"
 	"github.com/centrifuge/go-centrifuge/testingutils/testingtx"
 	"github.com/centrifuge/go-centrifuge/transactions"
 	"github.com/centrifuge/go-centrifuge/utils"
@@ -39,6 +41,7 @@ import (
 var ctx = map[string]interface{}{}
 var cfg config.Configuration
 var configService config.Service
+var defaultDID = testingidentity.GenerateRandomDID()
 
 func TestMain(m *testing.M) {
 	ethClient := &testingcommons.MockEthClient{}
@@ -202,10 +205,12 @@ func TestPOModel_calculateDataRoot(t *testing.T) {
 	assert.NotNil(t, poModel.PurchaseOrderSalts, "salts must be created")
 }
 
-func TestPOModel_GenerateProofs(t *testing.T) {
+func TestPOModel_CreateProofs(t *testing.T) {
 	po := createPurchaseOrder(t)
 	assert.NotNil(t, po)
-	proof, err := po.CreateProofs([]string{"po.po_number", documents.CDTreePrefix + ".next_version", documents.CDTreePrefix + ".document_type"})
+	rk := po.Document.Roles[0].RoleKey
+	pf := fmt.Sprintf(documents.CDTreePrefix+".roles[%s].collaborators[0]", hexutil.Encode(rk))
+	proof, err := po.CreateProofs([]string{"po.po_number", pf, documents.CDTreePrefix + ".document_type"})
 	assert.Nil(t, err)
 	assert.NotNil(t, proof)
 	tree, err := po.DocumentRootTree()
@@ -216,13 +221,14 @@ func TestPOModel_GenerateProofs(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, valid)
 
-	// Validate next_version
+	// Validate roles collaborators
 	valid, err = tree.ValidateProof(proof[1])
 	assert.Nil(t, err)
 	assert.True(t, valid)
 
 	// Validate []byte value
-	assert.Equal(t, po.NextVersion(), proof[1].Value)
+	acc := identity.NewDIDFromBytes(proof[1].Value)
+	assert.True(t, po.AccountCanRead(acc))
 
 	// Validate document_type
 	valid, err = tree.ValidateProof(proof[2])
@@ -247,7 +253,7 @@ func TestPOModel_getDocumentDataTree(t *testing.T) {
 
 func createPurchaseOrder(t *testing.T) *PurchaseOrder {
 	po := new(PurchaseOrder)
-	err := po.InitPurchaseOrderInput(testingdocuments.CreatePOPayload(), "0xBAEb33a61f05e6F269f1c4b4CFF91A901B54DaF7")
+	err := po.InitPurchaseOrderInput(testingdocuments.CreatePOPayload(), defaultDID.String())
 	assert.NoError(t, err)
 	_, err = po.CalculateDataRoot()
 	assert.NoError(t, err)

--- a/documents/purchaseorder/model_test.go
+++ b/documents/purchaseorder/model_test.go
@@ -205,7 +205,7 @@ func TestPOModel_calculateDataRoot(t *testing.T) {
 func TestPOModel_GenerateProofs(t *testing.T) {
 	po := createPurchaseOrder(t)
 	assert.NotNil(t, po)
-	proof, err := po.CreateProofs([]string{"po.po_number", documents.CDTreePrefix + ".collaborators[0]", documents.CDTreePrefix + ".document_type"})
+	proof, err := po.CreateProofs([]string{"po.po_number", documents.CDTreePrefix + ".next_version", documents.CDTreePrefix + ".document_type"})
 	assert.Nil(t, err)
 	assert.NotNil(t, proof)
 	tree, err := po.DocumentRootTree()
@@ -216,14 +216,13 @@ func TestPOModel_GenerateProofs(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, valid)
 
-	// Validate collaborators[0]
+	// Validate next_version
 	valid, err = tree.ValidateProof(proof[1])
 	assert.Nil(t, err)
 	assert.True(t, valid)
 
 	// Validate []byte value
-	id := identity.NewDIDFromBytes(proof[1].Value)
-	assert.True(t, po.CoreDocument.AccountCanRead(id))
+	assert.Equal(t, po.NextVersion(), proof[1].Value)
 
 	// Validate document_type
 	valid, err = tree.ValidateProof(proof[2])

--- a/documents/read_acls.go
+++ b/documents/read_acls.go
@@ -111,7 +111,7 @@ func (cd *CoreDocument) addNFTToReadRules(registry common.Address, tokenID []byt
 		return errors.New("failed to construct NFT: %v", err)
 	}
 
-	role := &coredocumentpb.Role{RoleKey: utils.RandomSlice(32)}
+	role := newRole()
 	role.Nfts = append(role.Nfts, nft)
 	cd.addNewRule(role, coredocumentpb.Action_ACTION_READ)
 	return cd.setSalts()
@@ -381,8 +381,7 @@ func (cd *CoreDocument) AddAccessToken(ctx context.Context, payload documentpb.A
 		return nil, err
 	}
 
-	role := new(coredocumentpb.Role)
-	role.RoleKey = utils.RandomSlice(32)
+	role := newRole()
 	at, err := assembleAccessToken(ctx, payload, role.RoleKey)
 	if err != nil {
 		return nil, errors.New("failed to construct access token: %v", err)
@@ -461,4 +460,9 @@ func assembleTokenMessage(tokenIdentifier []byte, granterID identity.DID, grante
 	tm = append(tm, roleID...)
 	tm = append(tm, docID...)
 	return tm, nil
+}
+
+// newRole returns a new role with random role key
+func newRole() *coredocumentpb.Role {
+	return &coredocumentpb.Role{RoleKey: utils.RandomSlice(32)}
 }

--- a/documents/read_acls.go
+++ b/documents/read_acls.go
@@ -63,19 +63,6 @@ func findRole(cd coredocumentpb.CoreDocument, onRole func(rridx, ridx int, role 
 	return false
 }
 
-// GetExternalCollaborators returns collaborators of a Document without the own centID.
-func (cd *CoreDocument) GetExternalCollaborators(self identity.DID) ([][]byte, error) {
-	var cs [][]byte
-	for _, c := range cd.Document.Collaborators {
-		id := identity.NewDIDFromBytes(c)
-		if !self.Equal(id) {
-			cs = append(cs, c)
-		}
-	}
-
-	return cs, nil
-}
-
 // NFTOwnerCanRead checks if the nft owner/account can read the Document
 func (cd *CoreDocument) NFTOwnerCanRead(tokenRegistry TokenRegistry, registry common.Address, tokenID []byte, account identity.DID) error {
 	// check if the account can read the doc
@@ -348,8 +335,8 @@ func isATInRole(role *coredocumentpb.Role, tokenID []byte) (*coredocumentpb.Acce
 // validateAT validates that given access token against its signature
 func validateAT(publicKey []byte, token *coredocumentpb.AccessToken, requesterID []byte) error {
 	// assemble token message from the token for validation
-	reqID := identity.NewDIDFromByte(requesterID)
-	granterID := identity.NewDIDFromByte(token.Granter)
+	reqID := identity.NewDIDFromBytes(requesterID)
+	granterID := identity.NewDIDFromBytes(token.Granter)
 	tm, err := assembleTokenMessage(token.Identifier, granterID, reqID, token.RoleIdentifier, token.DocumentIdentifier)
 	if err != nil {
 		return err
@@ -417,7 +404,7 @@ func assembleAccessToken(ctx context.Context, payload documentpb.AccessTokenPara
 	if err != nil {
 		return nil, err
 	}
-	granterID := identity.NewDIDFromByte(id)
+	granterID := identity.NewDIDFromBytes(id)
 	roleID := roleKey
 	granteeID, err := identity.NewDIDFromString(payload.Grantee)
 	if err != nil {

--- a/documents/read_acls_test.go
+++ b/documents/read_acls_test.go
@@ -333,7 +333,7 @@ func TestCoreDocumentModel_ATOwnerCanRead(t *testing.T) {
 	cd := newCoreDocument()
 	cd.Document.DocumentRoot = utils.RandomSlice(32)
 	id, err := account.GetIdentityID()
-	granteeID := identity.NewDIDFromByte(id)
+	granteeID := identity.NewDIDFromBytes(id)
 	assert.NoError(t, err)
 	payload := documentpb.AccessTokenParams{
 		Grantee:            hexutil.Encode(granteeID[:]),

--- a/identity/did.go
+++ b/identity/did.go
@@ -130,11 +130,6 @@ type Factory interface {
 	CalculateIdentityAddress(ctx context.Context) (*common.Address, error)
 }
 
-// NewDIDFromByte returns a DID based on a byte slice
-func NewDIDFromByte(did []byte) DID {
-	return DID(common.BytesToAddress(did))
-}
-
 // ServiceDID interface contains the methods to interact with the identity contract
 type ServiceDID interface {
 	// AddKey adds a key to identity contract

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -226,7 +226,7 @@ func (s *peer) GetSignaturesForDocument(ctx context.Context, model documents.Mod
 		return nil, errors.New("failed to get self ID")
 	}
 
-	cs, err := model.GetCollaborators(self.ID)
+	cs, err := model.GetSignCollaborators(self.ID)
 	if err != nil {
 		return nil, errors.New("failed to get external collaborators")
 	}

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -226,7 +226,7 @@ func (s *peer) GetSignaturesForDocument(ctx context.Context, model documents.Mod
 		return nil, errors.New("failed to get self ID")
 	}
 
-	cs, err := model.GetSignCollaborators(self.ID)
+	cs, err := model.GetSignerCollaborators(self.ID)
 	if err != nil {
 		return nil, errors.New("failed to get external collaborators")
 	}


### PR DESCRIPTION
This removes collaborators for the core document

Changes:
- Added `GetSignCollaborators` which should be used to get collaborators with sign permission. Ex: while requesting for signatures

- `GetCollaborators` will return collaborators with Read and Read_sign.

Fixes #679 and Fixes #680 