### PR TITLE
Expose p2p signature collection errors and ignore errors at correct level

### DIFF
--- a/documents/processor.go
+++ b/documents/processor.go
@@ -24,7 +24,7 @@ type Config interface {
 type Client interface {
 
 	// GetSignaturesForDocument gets the signatures for document
-	GetSignaturesForDocument(ctx context.Context, model Model) ([]*coredocumentpb.Signature, error)
+	GetSignaturesForDocument(ctx context.Context, model Model) ([]*coredocumentpb.Signature, []error, error)
 
 	// after all signatures are collected the sender sends the document including the signatures
 	SendAnchoredDocument(ctx context.Context, receiverID identity.DID, in *p2ppb.AnchorDocumentRequest) (*p2ppb.AnchorDocumentResponse, error)
@@ -100,7 +100,8 @@ func (dp defaultProcessor) RequestSignatures(ctx context.Context, model Model) e
 		return errors.New("failed to validate model for signature request: %v", err)
 	}
 
-	signs, err := dp.p2pClient.GetSignaturesForDocument(ctx, model)
+	// we ignore signature collection errors and anchor anyways
+	signs, _, err := dp.p2pClient.GetSignaturesForDocument(ctx, model)
 	if err != nil {
 		return errors.New("failed to collect signatures from the collaborators: %v", err)
 	}

--- a/documents/processor_test.go
+++ b/documents/processor_test.go
@@ -156,10 +156,10 @@ type p2pClient struct {
 	Client
 }
 
-func (p *p2pClient) GetSignaturesForDocument(ctx context.Context, model Model) ([]*coredocumentpb.Signature, error) {
+func (p *p2pClient) GetSignaturesForDocument(ctx context.Context, model Model) ([]*coredocumentpb.Signature, []error, error) {
 	args := p.Called(ctx, model)
 	sigs, _ := args.Get(0).([]*coredocumentpb.Signature)
-	return sigs, args.Error(1)
+	return sigs, nil, args.Error(1)
 }
 
 func (p *p2pClient) SendAnchoredDocument(ctx context.Context, receiverID identity.DID, in *p2ppb.AnchorDocumentRequest) (*p2ppb.AnchorDocumentResponse, error) {

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -212,28 +212,28 @@ func (s *peer) getSignatureAsync(ctx context.Context, cd coredocumentpb.CoreDocu
 }
 
 // GetSignaturesForDocument requests peer nodes for the signature, verifies them, and returns those signatures.
-func (s *peer) GetSignaturesForDocument(ctx context.Context, model documents.Model) (signatures []*coredocumentpb.Signature, err error) {
+func (s *peer) GetSignaturesForDocument(ctx context.Context, model documents.Model) (signatures []*coredocumentpb.Signature, signatureCollectionErrors []error, err error) {
 	in := make(chan signatureResponseWrap)
 	defer close(in)
 
 	nc, err := s.config.GetConfig()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	self, err := contextutil.Self(ctx)
 	if err != nil {
-		return nil, errors.New("failed to get self ID")
+		return nil, nil, errors.New("failed to get self ID")
 	}
 
 	cs, err := model.GetSignerCollaborators(self.ID)
 	if err != nil {
-		return nil, errors.New("failed to get external collaborators")
+		return nil, nil, errors.New("failed to get external collaborators")
 	}
 
 	cd, err := model.PackCoreDocument()
 	if err != nil {
-		return nil, errors.New("failed to pack core document: %v", err)
+		return nil, nil, errors.New("failed to pack core document: %v", err)
 	}
 
 	var count int
@@ -250,15 +250,15 @@ func (s *peer) GetSignaturesForDocument(ctx context.Context, model documents.Mod
 
 	for _, resp := range responses {
 		if resp.err != nil {
-			// this error is ignored since we would still anchor the document
-			log.Error(resp.err)
+			log.Warning(resp.err)
+			signatureCollectionErrors = append(signatureCollectionErrors, resp.err)
 			continue
 		}
 
 		signatures = append(signatures, resp.resp.Signature)
 	}
 
-	return signatures, nil
+	return signatures, signatureCollectionErrors, nil
 }
 
 func convertClientError(recv *p2ppb.Envelope) error {

--- a/p2p/client_integration_test.go
+++ b/p2p/client_integration_test.go
@@ -10,14 +10,13 @@ import (
 	"time"
 
 	"github.com/centrifuge/centrifuge-protobufs/gen/go/coredocument"
-	"github.com/centrifuge/go-centrifuge/crypto"
-
 	"github.com/centrifuge/centrifuge-protobufs/gen/go/p2p"
 	"github.com/centrifuge/go-centrifuge/bootstrap"
 	"github.com/centrifuge/go-centrifuge/bootstrap/bootstrappers/testingbootstrap"
 	"github.com/centrifuge/go-centrifuge/config"
 	"github.com/centrifuge/go-centrifuge/config/configstore"
 	"github.com/centrifuge/go-centrifuge/contextutil"
+	"github.com/centrifuge/go-centrifuge/crypto"
 	"github.com/centrifuge/go-centrifuge/documents"
 	"github.com/centrifuge/go-centrifuge/documents/purchaseorder"
 	"github.com/centrifuge/go-centrifuge/identity"
@@ -69,7 +68,7 @@ func TestClient_GetSignaturesForDocument(t *testing.T) {
 	ctxh, err := contextutil.New(context.Background(), acci)
 	assert.Nil(t, err)
 	dm := prepareDocumentForP2PHandler(t, [][]byte{tc.IdentityID})
-	signs, err := client.GetSignaturesForDocument(ctxh, dm)
+	signs, _, err := client.GetSignaturesForDocument(ctxh, dm)
 	assert.NoError(t, err)
 	assert.NotNil(t, signs)
 }
@@ -82,7 +81,7 @@ func TestClient_GetSignaturesForDocumentValidationCheck(t *testing.T) {
 	acci.IdentityID = defaultDID[:]
 	ctxh, err := contextutil.New(context.Background(), acci)
 	dm := prepareDocumentForP2PHandler(t, [][]byte{tc.IdentityID})
-	signs, err := client.GetSignaturesForDocument(ctxh, dm)
+	signs, _, err := client.GetSignaturesForDocument(ctxh, dm)
 	assert.NoError(t, err)
 	// one signature would be missing
 	assert.Equal(t, 0, len(signs))


### PR DESCRIPTION
<This is intended as a guide when describing-reviewing pull requests for go-centrifuge>
Issue Link: <Github link>
