### PR TITLE
Feat/write acls receive doc

### DIFF
--- a/documents/validator.go
+++ b/documents/validator.go
@@ -221,9 +221,9 @@ func anchoredValidator(repo anchors.AnchorRepository) Validator {
 	})
 }
 
-// TransitionValidator checks that the document model changes are within the transition_rule capability of the
-// identity making the changes
-func TransitionValidator(collaborator identity.DID) Validator {
+// transitionValidator checks that the document changes are within the transition_rule capability of the
+// collaborator making the changes
+func transitionValidator(collaborator identity.DID) Validator {
 	return ValidatorFunc(func(old, new Model) error {
 		if old == nil {
 			return nil
@@ -266,6 +266,19 @@ func PostAnchoredValidator(idService identity.ServiceDID, repo anchors.AnchorRep
 	return ValidatorGroup{
 		PreAnchorValidator(idService),
 		anchoredValidator(repo),
+	}
+}
+
+// ReceivedAnchoredDocumentValidator is a validator group with following validators
+// transitionValidator
+// PostAnchoredValidator
+func ReceivedAnchoredDocumentValidator(
+	idService identity.ServiceDID,
+	repo anchors.AnchorRepository,
+	collaborator identity.DID) ValidatorGroup {
+	return ValidatorGroup{
+		transitionValidator(collaborator),
+		PostAnchoredValidator(idService, repo),
 	}
 }
 

--- a/documents/validator_test.go
+++ b/documents/validator_test.go
@@ -247,7 +247,7 @@ func TestValidator_TransitionValidator(t *testing.T) {
 	updated := new(mockModel)
 
 	// does not error out if there is no old document model (if new model is the first version of the document model)
-	tv := TransitionValidator(id1)
+	tv := transitionValidator(id1)
 	err := tv.Validate(nil, updated)
 	assert.NoError(t, err)
 

--- a/p2p/receiver/handler_integration_test.go
+++ b/p2p/receiver/handler_integration_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/centrifuge/go-centrifuge/storage"
 	"github.com/centrifuge/go-centrifuge/testingutils/config"
 	"github.com/centrifuge/go-centrifuge/testingutils/documents"
+	"github.com/centrifuge/go-centrifuge/testingutils/identity"
 	"github.com/centrifuge/go-centrifuge/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -66,19 +67,17 @@ func TestMain(m *testing.M) {
 
 func TestHandler_GetDocument_nonexistentIdentifier(t *testing.T) {
 	b := utils.RandomSlice(32)
-	centrifugeId := createIdentity(t)
 	req := &p2ppb.GetDocumentRequest{DocumentIdentifier: b}
-	resp, err := handler.GetDocument(context.Background(), req, centrifugeId)
+	resp, err := handler.GetDocument(context.Background(), req, defaultDID)
 	assert.Error(t, err, "must return error")
 	assert.Nil(t, resp, "must be nil")
 }
 
 func TestHandler_HandleInterceptorReqSignature(t *testing.T) {
-	centID := createIdentity(t)
 	tc, err := configstore.NewAccount("main", cfg)
 	assert.Nil(t, err)
 	acc := tc.(*configstore.Account)
-	acc.IdentityID = centID[:]
+	acc.IdentityID = defaultDID[:]
 	ctxh, err := contextutil.New(context.Background(), acc)
 	assert.Nil(t, err)
 	_, err = cfgService.CreateAccount(acc)
@@ -94,7 +93,7 @@ func TestHandler_HandleInterceptorReqSignature(t *testing.T) {
 	peerID, err := cented25519.PublicKeyToP2PKey(bPk)
 	assert.NoError(t, err)
 
-	p2pResp, err := handler.HandleInterceptor(ctxh, peerID, p2pcommon.ProtocolForDID(&centID), p2pEnv)
+	p2pResp, err := handler.HandleInterceptor(ctxh, peerID, p2pcommon.ProtocolForDID(&defaultDID), p2pEnv)
 	assert.Nil(t, err, "must be nil")
 	assert.NotNil(t, p2pResp, "must be non nil")
 	resp := resolveSignatureResponse(t, p2pResp)
@@ -165,8 +164,10 @@ func TestHandler_SendAnchoredDocument_update_fail(t *testing.T) {
 	// Anchor document
 	accDID, err := contextutil.AccountDID(ctx)
 	assert.NoError(t, err)
-	anchorIDTyped, _ := anchors.ToAnchorID(cd.CurrentPreimage)
-	docRootTyped, _ := anchors.ToDocumentRoot(cd.DocumentRoot)
+	anchorIDTyped, err := anchors.ToAnchorID(cd.CurrentPreimage)
+	assert.NoError(t, err)
+	docRootTyped, err := anchors.ToDocumentRoot(cd.DocumentRoot)
+	assert.NoError(t, err)
 
 	anchorConfirmations, err := anchorRepo.CommitAnchor(ctx, anchorIDTyped, docRootTyped, [][anchors.DocumentProofLength]byte{utils.RandomByte32()})
 	assert.Nil(t, err)
@@ -192,9 +193,8 @@ func TestHandler_SendAnchoredDocument_EmptyDocument(t *testing.T) {
 func TestHandler_SendAnchoredDocument(t *testing.T) {
 	tc, err := configstore.NewAccount("main", cfg)
 	assert.Nil(t, err)
-	centrifugeId := createIdentity(t)
 	acc := tc.(*configstore.Account)
-	acc.IdentityID = centrifugeId[:]
+	acc.IdentityID = defaultDID[:]
 
 	ctxh, err := contextutil.New(context.Background(), tc)
 	assert.Nil(t, err)
@@ -210,8 +210,10 @@ func TestHandler_SendAnchoredDocument(t *testing.T) {
 	po.Document.DocumentRoot = tree.RootHash()
 
 	// Anchor document
-	anchorIDTyped, _ := anchors.ToAnchorID(po.Document.CurrentPreimage)
-	docRootTyped, _ := anchors.ToDocumentRoot(po.Document.DocumentRoot)
+	anchorIDTyped, err := anchors.ToAnchorID(po.Document.CurrentPreimage)
+	assert.NoError(t, err)
+	docRootTyped, err := anchors.ToDocumentRoot(po.Document.DocumentRoot)
+	assert.NoError(t, err)
 	anchorConfirmations, err := anchorRepo.CommitAnchor(ctxh, anchorIDTyped, docRootTyped, [][anchors.DocumentProofLength]byte{utils.RandomByte32()})
 	assert.Nil(t, err)
 
@@ -219,7 +221,44 @@ func TestHandler_SendAnchoredDocument(t *testing.T) {
 	assert.True(t, watchCommittedAnchor, "No error should be thrown by context")
 	cd, err = po.PackCoreDocument()
 	assert.NoError(t, err)
-	anchorResp, err := handler.SendAnchoredDocument(ctxh, &p2ppb.AnchorDocumentRequest{Document: &cd}, centrifugeId[:])
+
+	// this should succeed since this is the first document version
+	anchorResp, err := handler.SendAnchoredDocument(ctxh, &p2ppb.AnchorDocumentRequest{Document: &cd}, defaultDID[:])
+	assert.Nil(t, err)
+	assert.NotNil(t, anchorResp, "must be non nil")
+	assert.True(t, anchorResp.Accepted)
+
+	// update the document
+	npo, ncd := updateDocumentForP2Phandler(t, po)
+	resp, err = handler.RequestDocumentSignature(ctxh, &p2ppb.SignatureRequest{Document: &ncd})
+	assert.Nil(t, err)
+	assert.NotNil(t, resp)
+
+	// Add signature received
+	npo.AppendSignatures(resp.Signature)
+	tree, err = npo.DocumentRootTree()
+	npo.Document.DocumentRoot = tree.RootHash()
+
+	// Anchor document
+	anchorIDTyped, err = anchors.ToAnchorID(npo.Document.CurrentPreimage)
+	assert.NoError(t, err)
+	docRootTyped, err = anchors.ToDocumentRoot(npo.Document.DocumentRoot)
+	assert.NoError(t, err)
+	anchorConfirmations, err = anchorRepo.CommitAnchor(ctxh, anchorIDTyped, docRootTyped, [][anchors.DocumentProofLength]byte{utils.RandomByte32()})
+	assert.Nil(t, err)
+
+	watchCommittedAnchor = <-anchorConfirmations
+	assert.True(t, watchCommittedAnchor, "No error should be thrown by context")
+	ncd, err = npo.PackCoreDocument()
+	assert.NoError(t, err)
+
+	// transition failure for random ID
+	id := testingidentity.GenerateRandomDID()
+	_, err = handler.SendAnchoredDocument(ctxh, &p2ppb.AnchorDocumentRequest{Document: &ncd}, id[:])
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid document state transition")
+
+	anchorResp, err = handler.SendAnchoredDocument(ctxh, &p2ppb.AnchorDocumentRequest{Document: &ncd}, defaultDID[:])
 	assert.Nil(t, err)
 	assert.NotNil(t, anchorResp, "must be non nil")
 	assert.True(t, anchorResp.Accepted)

--- a/testingutils/documents/documents.go
+++ b/testingutils/documents/documents.go
@@ -61,6 +61,11 @@ type MockModel struct {
 	mock.Mock
 }
 
+func (m *MockModel) PreviousVersion() []byte {
+	args := m.Called()
+	return args.Get(0).([]byte)
+}
+
 func (m *MockModel) CurrentVersion() []byte {
 	args := m.Called()
 	return args.Get(0).([]byte)

--- a/testworld/document_consensus_test.go
+++ b/testworld/document_consensus_test.go
@@ -74,6 +74,10 @@ func addExternalCollaborator_withinHost(t *testing.T, documentType string) {
 	getDocumentAndCheck(bob.httpExpect, b, documentType, params)
 	nonExistingDocumentCheck(bob.httpExpect, c, documentType, params)
 
+	//// let c update the document and fail
+	//res = failedUpdateDocument(bob.httpExpect, c, documentType, http.StatusInternalServerError, docIdentifier, updatedDocumentPayload(documentType, []string{a, c}))
+	//assert.NotNil(t, res)
+
 	// b updates invoice and shares with c as well
 	res = updateDocument(bob.httpExpect, b, documentType, http.StatusOK, docIdentifier, updatedDocumentPayload(documentType, []string{a, c}))
 	txID = getTransactionID(t, res)
@@ -121,6 +125,10 @@ func addExternalCollaborator_multiHostMultiAccount(t *testing.T, documentType st
 	getDocumentAndCheck(bob.httpExpect, b, documentType, params)
 	nonExistingDocumentCheck(bob.httpExpect, c, documentType, params)
 
+	//// let c update the document and fail
+	//res = failedUpdateDocument(bob.httpExpect, c, documentType, http.StatusInternalServerError, docIdentifier, updatedDocumentPayload(documentType, []string{alice.id.String(), b, c, d, e}))
+	//assert.NotNil(t, res)
+
 	// Bob updates invoice and shares with bobs account c as well using account a and to accounts d and e of Charlie
 	res = updateDocument(bob.httpExpect, a, documentType, http.StatusOK, docIdentifier, updatedDocumentPayload(documentType, []string{alice.id.String(), b, c, d, e}))
 	txID = getTransactionID(t, res)
@@ -163,6 +171,10 @@ func addExternalCollaborator(t *testing.T, documentType string) {
 	getDocumentAndCheck(alice.httpExpect, alice.id.String(), documentType, params)
 	getDocumentAndCheck(bob.httpExpect, bob.id.String(), documentType, params)
 	nonExistingDocumentCheck(charlie.httpExpect, charlie.id.String(), documentType, params)
+
+	//// let charlie update the document and fail
+	//res = failedUpdateDocument(charlie.httpExpect, charlie.id.String(), documentType, http.StatusInternalServerError, docIdentifier, updatedDocumentPayload(documentType, []string{alice.id.String(), charlie.id.String()}))
+	//assert.NotNil(t, res)
 
 	// Bob updates invoice and shares with Charlie as well
 	res = updateDocument(bob.httpExpect, bob.id.String(), documentType, http.StatusOK, docIdentifier, updatedDocumentPayload(documentType, []string{alice.id.String(), charlie.id.String()}))

--- a/testworld/httputils.go
+++ b/testworld/httputils.go
@@ -53,6 +53,13 @@ func createDocument(e *httpexpect.Expect, auth string, documentType string, stat
 	return obj
 }
 
+func failedUpdateDocument(e *httpexpect.Expect, auth string, documentType string, status int, docIdentifier string, payload map[string]interface{}) *httpexpect.Object {
+	obj := addCommonHeaders(e.PUT("/"+documentType+"/"+docIdentifier), auth).
+		WithJSON(payload).
+		Expect().Status(status).JSON().Object()
+	return obj
+}
+
 func updateDocument(e *httpexpect.Expect, auth string, documentType string, status int, docIdentifier string, payload map[string]interface{}) *httpexpect.Object {
 	obj := addCommonHeaders(e.PUT("/"+documentType+"/"+docIdentifier), auth).
 		WithJSON(payload).


### PR DESCRIPTION
Fixes #838 

Also, removed creating identities in every test. this should improve our integration tests run time

Note: testworld tests that check for transition failures are disabled until #807 is done