### PR TITLE
remove unused function from model

### DIFF
--- a/documents/entity/model.go
+++ b/documents/entity/model.go
@@ -279,15 +279,6 @@ func (e *Entity) CalculateDocumentRoot() ([]byte, error) {
 	return e.CoreDocument.CalculateDocumentRoot(e.DocumentType(), dr)
 }
 
-// GetSigningRootProofHash gets the signing root proof hash upto document root
-func (e *Entity) GetSigningRootProofHash() (hash []byte, err error) {
-	dr, err := e.CalculateDataRoot()
-	if err != nil {
-		return dr, err
-	}
-	return e.CoreDocument.GetSigningRootProofHash(e.DocumentType(), dr)
-}
-
 // DocumentRootTree creates and returns the document root tree
 func (e *Entity) DocumentRootTree() (tree *proofs.DocumentTree, err error) {
 	dr, err := e.CalculateDataRoot()

--- a/documents/invoice/model.go
+++ b/documents/invoice/model.go
@@ -675,15 +675,6 @@ func (i *Invoice) CalculateSigningRoot() ([]byte, error) {
 	return i.CoreDocument.CalculateSigningRoot(i.DocumentType(), dr)
 }
 
-// GetSigningRootProofHash gets the signing root proof hash upto document root
-func (i *Invoice) GetSigningRootProofHash() (hash []byte, err error) {
-	dr, err := i.CalculateDataRoot()
-	if err != nil {
-		return dr, err
-	}
-	return i.CoreDocument.GetSigningRootProofHash(i.DocumentType(), dr)
-}
-
 // CalculateDocumentRoot calculates the document root
 func (i *Invoice) CalculateDocumentRoot() ([]byte, error) {
 	dr, err := i.CalculateDataRoot()

--- a/documents/model.go
+++ b/documents/model.go
@@ -52,9 +52,6 @@ type Model interface {
 	// CalculateDocumentRoot returns the document root of the model.
 	CalculateDocumentRoot() ([]byte, error)
 
-	// GetSigningRootProofHash get the hash for signing root of the model.
-	GetSigningRootProofHash() (hash []byte, err error)
-
 	// CalculateSignaturesRoot returns signatures root of the model.
 	CalculateSignaturesRoot() ([]byte, error)
 

--- a/documents/purchaseorder/model.go
+++ b/documents/purchaseorder/model.go
@@ -396,15 +396,6 @@ func (p *PurchaseOrder) CalculateSigningRoot() ([]byte, error) {
 	return p.CoreDocument.CalculateSigningRoot(p.DocumentType(), dr)
 }
 
-// GetSigningRootProofHash gets the signing root proof hash upto document root
-func (p *PurchaseOrder) GetSigningRootProofHash() (hash []byte, err error) {
-	dr, err := p.CalculateDataRoot()
-	if err != nil {
-		return dr, err
-	}
-	return p.CoreDocument.GetSigningRootProofHash(p.DocumentType(), dr)
-}
-
 // CalculateDocumentRoot calculates the document root
 func (p *PurchaseOrder) CalculateDocumentRoot() ([]byte, error) {
 	dr, err := p.CalculateDataRoot()


### PR DESCRIPTION
We seem to have missed this during the proof creation cleanup. The `GetSiningRootHash` is not being used through model anywhere. The method on the CoreDocument is being used with a wrong meaning IMO. 
