### PR TITLE
create new document with embedded Access Token, add test coverage for CoreDocument

### DIFF
--- a/documents/coredocument.go
+++ b/documents/coredocument.go
@@ -1,8 +1,11 @@
 package documents
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
+	"github.com/centrifuge/go-centrifuge/protobufs/gen/go/document"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"strings"
 	"time"
 
@@ -112,6 +115,28 @@ func NewCoreDocumentWithCollaborators(documentPrefix []byte, collaborators Colla
 
 	cd.initReadRules(append(collaborators.ReadCollaborators, collaborators.ReadWriteCollaborators...))
 	cd.initTransitionRules(documentPrefix, collaborators.ReadWriteCollaborators)
+	return cd, nil
+}
+
+// NewCoreDocumentWithAccessToken generates a new core document with a document type specified by the prefix.
+// It also adds the targetID as a read collaborator, and adds an access token on this document for the document specified in the documentID parameter
+func NewCoreDocumentWithAccessToken(ctx context.Context, documentPrefix []byte, targetID identity.DID, documentID []byte) (*CoreDocument, error) {
+	did := &CollaboratorsAccess{
+		ReadCollaborators: []identity.DID{targetID},
+		ReadWriteCollaborators: nil,
+	}
+	cd, err := NewCoreDocumentWithCollaborators(documentPrefix, *did)
+	if err != nil {
+		return nil, err
+	}
+	at := &documentpb.AccessTokenParams{
+		Grantee: targetID.String(),
+		DocumentIdentifier: hexutil.Encode(documentID),
+	}
+	cd, err = cd.AddAccessToken(ctx, *at)
+	if err != nil {
+		return nil, err
+	}
 	return cd, nil
 }
 

--- a/documents/coredocument.go
+++ b/documents/coredocument.go
@@ -132,10 +132,11 @@ func NewCoreDocumentWithAccessToken(ctx context.Context, documentPrefix []byte, 
 	if err != nil {
 		return nil, err
 	}
-	cd, err = cd.AddAccessToken(ctx, params)
+	at, err := assembleAccessToken(ctx, params, cd.CurrentVersion())
 	if err != nil {
-		return nil, err
+		return nil, errors.New("failed to construct access token: %v", err)
 	}
+	cd.Document.AccessTokens = append(cd.Document.AccessTokens, at)
 	return cd, nil
 }
 

--- a/documents/coredocument.go
+++ b/documents/coredocument.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"github.com/centrifuge/go-centrifuge/protobufs/gen/go/document"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"strings"
 	"time"
+
+	"github.com/centrifuge/go-centrifuge/protobufs/gen/go/document"
 
 	"github.com/centrifuge/centrifuge-protobufs/gen/go/coredocument"
 	"github.com/centrifuge/go-centrifuge/crypto"
@@ -120,20 +120,20 @@ func NewCoreDocumentWithCollaborators(documentPrefix []byte, collaborators Colla
 
 // NewCoreDocumentWithAccessToken generates a new core document with a document type specified by the prefix.
 // It also adds the targetID as a read collaborator, and adds an access token on this document for the document specified in the documentID parameter
-func NewCoreDocumentWithAccessToken(ctx context.Context, documentPrefix []byte, targetID identity.DID, documentID []byte) (*CoreDocument, error) {
-	did := &CollaboratorsAccess{
-		ReadCollaborators: []identity.DID{targetID},
-		ReadWriteCollaborators: nil,
-	}
-	cd, err := NewCoreDocumentWithCollaborators(documentPrefix, *did)
+func NewCoreDocumentWithAccessToken(ctx context.Context, documentPrefix []byte, params documentpb.AccessTokenParams) (*CoreDocument, error) {
+	did, err := identity.StringsToDIDs(params.Grantee)
 	if err != nil {
 		return nil, err
 	}
-	at := &documentpb.AccessTokenParams{
-		Grantee: targetID.String(),
-		DocumentIdentifier: hexutil.Encode(documentID),
+	collaborators := &CollaboratorsAccess{
+		ReadCollaborators:      []identity.DID{*did[0]},
+		ReadWriteCollaborators: nil,
 	}
-	cd, err = cd.AddAccessToken(ctx, *at)
+	cd, err := NewCoreDocumentWithCollaborators(documentPrefix, *collaborators)
+	if err != nil {
+		return nil, err
+	}
+	cd, err = cd.AddAccessToken(ctx, params)
 	if err != nil {
 		return nil, err
 	}

--- a/documents/coredocument.go
+++ b/documents/coredocument.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/centrifuge/go-centrifuge/protobufs/gen/go/document"
 	"github.com/centrifuge/centrifuge-protobufs/gen/go/coredocument"
 	"github.com/centrifuge/go-centrifuge/crypto"
 	"github.com/centrifuge/go-centrifuge/errors"
 	"github.com/centrifuge/go-centrifuge/identity"
+	"github.com/centrifuge/go-centrifuge/protobufs/gen/go/document"
 	"github.com/centrifuge/go-centrifuge/utils"
 	"github.com/centrifuge/precise-proofs/proofs"
 	"github.com/centrifuge/precise-proofs/proofs/proto"

--- a/documents/coredocument.go
+++ b/documents/coredocument.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/centrifuge/go-centrifuge/protobufs/gen/go/document"
-
 	"github.com/centrifuge/centrifuge-protobufs/gen/go/coredocument"
 	"github.com/centrifuge/go-centrifuge/crypto"
 	"github.com/centrifuge/go-centrifuge/errors"

--- a/documents/coredocument_test.go
+++ b/documents/coredocument_test.go
@@ -258,6 +258,16 @@ func TestCoreDocument_PrepareNewVersion(t *testing.T) {
 	assert.Equal(t, ncd.GetTestCoreDocWithReset().Roles[1].Collaborators[1], c4[:])
 }
 
+func TestCoreDocument_newRoleWithCollaborators(t *testing.T) {
+	did1 := testingidentity.GenerateRandomDID()
+	did2 := testingidentity.GenerateRandomDID()
+
+	role := newRoleWithCollaborators(did1, did2)
+	assert.Len(t, role.Collaborators, 2)
+	assert.Equal(t, role.Collaborators[0], did1[:])
+	assert.Equal(t, role.Collaborators[1], did2[:])
+}
+
 func TestGetSigningProofHash(t *testing.T) {
 	docAny := &any.Any{
 		TypeUrl: documenttypes.InvoiceDataTypeUrl,

--- a/documents/coredocument_test.go
+++ b/documents/coredocument_test.go
@@ -8,9 +8,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/centrifuge/go-centrifuge/protobufs/gen/go/document"
-	"github.com/centrifuge/go-centrifuge/testingutils/config"
-
 	"github.com/centrifuge/centrifuge-protobufs/documenttypes"
 	"github.com/centrifuge/centrifuge-protobufs/gen/go/coredocument"
 	"github.com/centrifuge/go-centrifuge/anchors"
@@ -20,9 +17,11 @@ import (
 	"github.com/centrifuge/go-centrifuge/config/configstore"
 	"github.com/centrifuge/go-centrifuge/ethereum"
 	"github.com/centrifuge/go-centrifuge/identity"
+	"github.com/centrifuge/go-centrifuge/protobufs/gen/go/document"
 	"github.com/centrifuge/go-centrifuge/queue"
 	"github.com/centrifuge/go-centrifuge/storage/leveldb"
 	"github.com/centrifuge/go-centrifuge/testingutils/commons"
+	"github.com/centrifuge/go-centrifuge/testingutils/config"
 	"github.com/centrifuge/go-centrifuge/testingutils/identity"
 	"github.com/centrifuge/go-centrifuge/transactions/txv1"
 	"github.com/centrifuge/go-centrifuge/utils"

--- a/documents/coredocument_test.go
+++ b/documents/coredocument_test.go
@@ -156,6 +156,22 @@ func TestCoreDocument_ID(t *testing.T) {
 	assert.Equal(t, cd.Document.DocumentIdentifier, cd.ID())
 }
 
+func TestCoreDocument_NewCoreDocumentWithCollaborators(t *testing.T) {
+	did1 := testingidentity.GenerateRandomDID()
+	did2 := testingidentity.GenerateRandomDID()
+	c := &CollaboratorsAccess{
+		ReadCollaborators: []identity.DID{did1},
+		ReadWriteCollaborators: []identity.DID{did2},
+	}
+	cd, err := NewCoreDocumentWithCollaborators([]byte("inv"), *c)
+	assert.NoError(t, err)
+
+	collabs, err := cd.GetCollaborators(identity.DID{})
+	assert.NoError(t, err)
+	assert.Equal(t, did1, collabs.ReadCollaborators[0])
+	assert.Equal(t, did2, collabs.ReadWriteCollaborators[0])
+}
+
 func TestCoreDocument_PrepareNewVersion(t *testing.T) {
 	cd, err := newCoreDocument()
 	assert.NoError(t, err)

--- a/documents/coredocument_test.go
+++ b/documents/coredocument_test.go
@@ -107,6 +107,55 @@ func Test_fetchUniqueCollaborators(t *testing.T) {
 	}
 }
 
+func TestCoreDocument_CurrentVersion(t *testing.T) {
+	cd, err := newCoreDocument()
+	assert.NoError(t, err)
+
+	assert.Equal(t, cd.CurrentVersion(), cd.Document.CurrentVersion)
+}
+
+func TestCoreDocument_PreviousVersion(t *testing.T) {
+	cd, err := newCoreDocument()
+	assert.NoError(t, err)
+
+	assert.Equal(t, cd.PreviousVersion(), cd.Document.PreviousVersion)
+}
+
+func TestCoreDocument_NextVersion(t *testing.T) {
+	cd, err := newCoreDocument()
+	assert.NoError(t, err)
+
+	assert.Equal(t, cd.NextVersion(), cd.Document.NextVersion)
+}
+
+func TestCoreDocument_CurrentVersionPreimage(t *testing.T) {
+	cd, err := newCoreDocument()
+	assert.NoError(t, err)
+
+	assert.Equal(t, cd.CurrentVersionPreimage(), cd.Document.CurrentPreimage)
+}
+
+func TestCoreDocument_Author(t *testing.T) {
+	cd, err := newCoreDocument()
+	assert.NoError(t, err)
+
+	did := testingidentity.GenerateRandomDID()
+	cd.Document.Author = did[:]
+	a, err := cd.Author()
+	assert.NoError(t, err)
+
+	aID, err := identity.NewDIDFromBytes(cd.Document.Author)
+	assert.NoError(t, err)
+	assert.Equal(t, a, aID)
+}
+
+func TestCoreDocument_ID(t *testing.T) {
+	cd, err := newCoreDocument()
+	assert.NoError(t, err)
+
+	assert.Equal(t, cd.Document.DocumentIdentifier, cd.ID())
+}
+
 func TestCoreDocument_PrepareNewVersion(t *testing.T) {
 	cd, err := newCoreDocument()
 	assert.NoError(t, err)

--- a/documents/coredocument_test.go
+++ b/documents/coredocument_test.go
@@ -182,11 +182,29 @@ func TestNewCoreDocumentWithAccessToken(t *testing.T) {
 	ctxh := testingconfig.CreateAccountContext(t, cfg)
 	id := hexutil.Encode(cd.Document.DocumentIdentifier)
 	did1 := testingidentity.GenerateRandomDID()
+
+	// wrong granteeID format
 	at := &documentpb.AccessTokenParams{
-		Grantee:            did1.String(),
+		Grantee:            "random string",
 		DocumentIdentifier: id,
 	}
 	ncd, err := NewCoreDocumentWithAccessToken(ctxh, CompactProperties("inv"), *at)
+	assert.Error(t, err)
+
+	// wrong docID
+	at = &documentpb.AccessTokenParams{
+		Grantee:            did1.String(),
+		DocumentIdentifier: "random string",
+	}
+	ncd, err = NewCoreDocumentWithAccessToken(ctxh, CompactProperties("inv"), *at)
+	assert.Error(t, err)
+
+	// correct access token params
+	at = &documentpb.AccessTokenParams{
+		Grantee:            did1.String(),
+		DocumentIdentifier: id,
+	}
+	ncd, err = NewCoreDocumentWithAccessToken(ctxh, CompactProperties("inv"), *at)
 	assert.NoError(t, err)
 
 	token := ncd.Document.AccessTokens[0]

--- a/documents/coredocument_test.go
+++ b/documents/coredocument_test.go
@@ -160,7 +160,7 @@ func TestCoreDocument_NewCoreDocumentWithCollaborators(t *testing.T) {
 	did1 := testingidentity.GenerateRandomDID()
 	did2 := testingidentity.GenerateRandomDID()
 	c := &CollaboratorsAccess{
-		ReadCollaborators: []identity.DID{did1},
+		ReadCollaborators:      []identity.DID{did1},
 		ReadWriteCollaborators: []identity.DID{did2},
 	}
 	cd, err := NewCoreDocumentWithCollaborators([]byte("inv"), *c)

--- a/documents/coredocument_test.go
+++ b/documents/coredocument_test.go
@@ -268,6 +268,17 @@ func TestCoreDocument_newRoleWithCollaborators(t *testing.T) {
 	assert.Equal(t, role.Collaborators[1], did2[:])
 }
 
+func TestCoreDocument_AddUpdateLog(t *testing.T) {
+	did1 := testingidentity.GenerateRandomDID()
+	cd, err := newCoreDocument()
+	assert.NoError(t, err)
+
+	err = cd.AddUpdateLog(did1)
+	assert.NoError(t, err)
+	assert.Equal(t, cd.Document.Author, did1[:])
+	assert.True(t, cd.Modified)
+}
+
 func TestGetSigningProofHash(t *testing.T) {
 	docAny := &any.Any{
 		TypeUrl: documenttypes.InvoiceDataTypeUrl,


### PR DESCRIPTION
<This is intended as a guide when describing-reviewing pull requests for go-centrifuge>
Closes #912.
