### PR TITLE
add subkey to docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,6 @@ jobs:
        - touch ./build/peak-vista-185616-9f70002df7eb.json.enc
        - echo $CREDENTIALS_GCP | base64 -d > ./build/peak-vista-185616-9f70002df7eb.json.enc
        - openssl aes-256-cbc -K $encrypted_f84a564476a2_key -iv $encrypted_f84a564476a2_iv -in ./build/peak-vista-185616-9f70002df7eb.json.enc -out ./build/peak-vista-185616-9f70002df7eb.json -d
-       - cp $HOME/.cargo/bin/subkey .
       script: make build-ci
       after_script:
        - ./build/scripts/push_to_swagger.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ jobs:
        - touch ./build/peak-vista-185616-9f70002df7eb.json.enc
        - echo $CREDENTIALS_GCP | base64 -d > ./build/peak-vista-185616-9f70002df7eb.json.enc
        - openssl aes-256-cbc -K $encrypted_f84a564476a2_key -iv $encrypted_f84a564476a2_iv -in ./build/peak-vista-185616-9f70002df7eb.json.enc -out ./build/peak-vista-185616-9f70002df7eb.json -d
+       - cp $HOME/.cargo/bin/subkey .
       script: make build-ci
       after_script:
        - ./build/scripts/push_to_swagger.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
-FROM golang:1.11-alpine as builder
-
-RUN apk update && apk add --no-cache openssh git jq curl gcc libc-dev build-base
+FROM golang:1.11-stretch as builder
 
 ADD . /go/src/github.com/centrifuge/go-centrifuge
 WORKDIR /go/src/github.com/centrifuge/go-centrifuge
 
 RUN go install -ldflags "-X github.com/centrifuge/go-centrifuge/version.gitCommit=`git rev-parse HEAD`" ./cmd/centrifuge/...
 
-FROM alpine:latest
+FROM debian:stretch-slim
 
-RUN apk update && apk add --no-cache jq curl
+COPY ./subkey /usr/local/bin
+RUN /usr/local/bin/subkey --version
 
 WORKDIR /root/
 COPY --from=builder /go/bin/centrifuge .


### PR DESCRIPTION
Add subkey to docker build.

Moved from alpine to Debian since the subkey binary doesn't seem to work on the Alpine. Hopefully, this is temporary until we have a subkey lib in golang