### PR TITLE
1 - Transition Rules: Create API

### DIFF
--- a/documents/coredocument.go
+++ b/documents/coredocument.go
@@ -747,7 +747,14 @@ func (cd *CoreDocument) GetSignerCollaborators(filterIDs ...identity.DID) ([]ide
 		return nil, err
 	}
 
-	return filterCollaborators(sign, filterIDs...), nil
+	wcs, err := cd.getWriteCollaborators(coredocumentpb.TransitionAction_TRANSITION_ACTION_EDIT)
+	if err != nil {
+		return nil, err
+	}
+
+	wc := filterCollaborators(wcs, filterIDs...)
+	rc := filterCollaborators(sign, filterIDs...)
+	return identity.RemoveDuplicateDIDs(append(wc, rc...)), nil
 }
 
 // GetCollaborators returns the collaborators excluding the filteredIDs

--- a/documents/coredocument.go
+++ b/documents/coredocument.go
@@ -740,7 +740,7 @@ func (cd *CoreDocument) coredocTree(docType string) (tree *proofs.DocumentTree, 
 }
 
 // GetSignerCollaborators returns the collaborators excluding the filteredIDs
-// returns collaborators with Read_Sign permissions.
+// returns collaborators with Action_ACTION_READ_SIGN and TransitionAction_TRANSITION_ACTION_EDIT permissions.
 func (cd *CoreDocument) GetSignerCollaborators(filterIDs ...identity.DID) ([]identity.DID, error) {
 	sign, err := cd.getReadCollaborators(coredocumentpb.Action_ACTION_READ_SIGN)
 	if err != nil {

--- a/documents/model.go
+++ b/documents/model.go
@@ -157,6 +157,10 @@ type Model interface {
 
 	// UpdateRole updates existing role with provided collaborators
 	UpdateRole(rk []byte, collabs []identity.DID) (*coredocumentpb.Role, error)
+
+	// AddTransitionRules creates a new transition rule to edit an attribute.
+	// The access is only given to the roleKey which is expected to be present already.
+	AddTransitionRuleForAttribute(roleID []byte, key AttrKey) (*coredocumentpb.TransitionRule, error)
 }
 
 // TokenRegistry defines NFT related functions.

--- a/documents/read_acls.go
+++ b/documents/read_acls.go
@@ -85,7 +85,7 @@ func findReadRole(cd coredocumentpb.CoreDocument, onRole func(rridx, ridx int, r
 	return false
 }
 
-// findRole calls OnRole for every role that matches the actions passed in
+// findTransitionRole calls OnRole for every role that matches the actions passed in
 func findTransitionRole(cd coredocumentpb.CoreDocument, onRole func(rridx, ridx int, role *coredocumentpb.Role) bool, actions ...coredocumentpb.TransitionAction) bool {
 	am := make(map[int32]struct{})
 	for _, a := range actions {

--- a/documents/test_documents.go
+++ b/documents/test_documents.go
@@ -91,6 +91,12 @@ func (m *MockModel) UpdateRole(roleID []byte, dids []identity.DID) (*coredocumen
 	return r, args.Error(1)
 }
 
+func (m *MockModel) AddTransitionRuleForAttribute(roleID []byte, key AttrKey) (*coredocumentpb.TransitionRule, error) {
+	args := m.Called(roleID, key)
+	r, _ := args.Get(0).(*coredocumentpb.TransitionRule)
+	return r, args.Error(1)
+}
+
 type MockService struct {
 	Service
 	mock.Mock

--- a/documents/write_acls.go
+++ b/documents/write_acls.go
@@ -236,7 +236,7 @@ func (cd *CoreDocument) addCollaboratorsToTransitionRules(documentPrefix []byte,
 	cd.Modified = true
 }
 
-// addNewTransitionRule creates a new transition rule with the given parameters.
+// addNewTransitionRule creates a new transition rule with the given parameters and returns the rule
 func (cd *CoreDocument) addNewTransitionRule(roleKey []byte, matchType coredocumentpb.FieldMatchType, field []byte, action coredocumentpb.TransitionAction) *coredocumentpb.TransitionRule {
 	rule := &coredocumentpb.TransitionRule{
 		RuleKey:   utils.RandomSlice(32),
@@ -277,9 +277,9 @@ func defaultRuleFieldProps() map[string][]byte {
 	return fieldMap
 }
 
-// shouldAddRole checks if the role exists in the rule that has a field in the field map.
+// deleteFieldIfRoleExists checks if the role exists in the rule that has a field in the field map.
 // will update the fieldMap by deleting fields that already has the role
-func shouldAddRole(rule *coredocumentpb.TransitionRule, role []byte, fieldMap map[string][]byte) bool {
+func deleteFieldIfRoleExists(rule *coredocumentpb.TransitionRule, role []byte, fieldMap map[string][]byte) bool {
 	field := hexutil.Encode(rule.Field)
 	if rule.MatchType != coredocumentpb.FieldMatchType_FIELD_MATCH_TYPE_EXACT {
 		// default field rules are exact match
@@ -305,7 +305,7 @@ func shouldAddRole(rule *coredocumentpb.TransitionRule, role []byte, fieldMap ma
 func (cd *CoreDocument) addDefaultRules(roleKey []byte) {
 	fieldMap := defaultRuleFieldProps()
 	for _, rule := range cd.Document.TransitionRules {
-		if !shouldAddRole(rule, roleKey, fieldMap) {
+		if !deleteFieldIfRoleExists(rule, roleKey, fieldMap) {
 			continue
 		}
 
@@ -328,6 +328,7 @@ func (cd *CoreDocument) addDefaultRules(roleKey []byte) {
 }
 
 // AddTransitionRuleForAttribute adds a new rule with key as fields for the role
+//
 // Role must be present to create a rule.
 func (cd *CoreDocument) AddTransitionRuleForAttribute(roleID []byte, key AttrKey) (*coredocumentpb.TransitionRule, error) {
 	_, err := cd.GetRole(roleID)

--- a/documents/write_acls.go
+++ b/documents/write_acls.go
@@ -7,7 +7,9 @@ import (
 	"github.com/centrifuge/go-centrifuge/errors"
 	"github.com/centrifuge/go-centrifuge/identity"
 	"github.com/centrifuge/go-centrifuge/utils"
+	"github.com/centrifuge/go-centrifuge/utils/byteutils"
 	"github.com/centrifuge/precise-proofs/proofs"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 // ChangedField holds the compact property, old and new value of the field that is changed
@@ -235,7 +237,7 @@ func (cd *CoreDocument) addCollaboratorsToTransitionRules(documentPrefix []byte,
 }
 
 // addNewTransitionRule creates a new transition rule with the given parameters.
-func (cd *CoreDocument) addNewTransitionRule(roleKey []byte, matchType coredocumentpb.FieldMatchType, field []byte, action coredocumentpb.TransitionAction) {
+func (cd *CoreDocument) addNewTransitionRule(roleKey []byte, matchType coredocumentpb.FieldMatchType, field []byte, action coredocumentpb.TransitionAction) *coredocumentpb.TransitionRule {
 	rule := &coredocumentpb.TransitionRule{
 		RuleKey:   utils.RandomSlice(32),
 		MatchType: matchType,
@@ -245,4 +247,99 @@ func (cd *CoreDocument) addNewTransitionRule(roleKey []byte, matchType coredocum
 	}
 	cd.Document.TransitionRules = append(cd.Document.TransitionRules, rule)
 	cd.Modified = true
+	return rule
+}
+
+var attributeCompactPrefix = [...]byte{1, 0, 0, 0, 0, 0, 0, 28}
+
+// getAttributeField creates a compact property of the attribute key
+func getAttributeField(key AttrKey) []byte {
+	return append(attributeCompactPrefix[:], key[:]...)
+}
+
+// defaultRuleFieldProps are the fields that every collaborator should have rule set for to update a document.
+func defaultRuleFieldProps() map[string][]byte {
+	fields := [][]byte{
+		{1, 0, 0, 0, 0, 0, 0, 3},  // current_version
+		{1, 0, 0, 0, 0, 0, 0, 4},  // next_version
+		{1, 0, 0, 0, 0, 0, 0, 16}, // previous_version
+		{1, 0, 0, 0, 0, 0, 0, 22}, // next_preimage
+		{1, 0, 0, 0, 0, 0, 0, 23}, // current_preimage
+		{1, 0, 0, 0, 0, 0, 0, 25}, // author
+		{1, 0, 0, 0, 0, 0, 0, 26}, // timestamp
+	}
+
+	fieldMap := make(map[string][]byte)
+	for _, f := range fields {
+		f := f
+		fieldMap[hexutil.Encode(f)] = f
+	}
+	return fieldMap
+}
+
+// shouldAddRole checks if the role exists in the rule that has a field in the field map.
+// will update the fieldMap by deleting fields that already has the role
+func shouldAddRole(rule *coredocumentpb.TransitionRule, role []byte, fieldMap map[string][]byte) bool {
+	field := hexutil.Encode(rule.Field)
+	if rule.MatchType != coredocumentpb.FieldMatchType_FIELD_MATCH_TYPE_EXACT {
+		// default field rules are exact match
+		return false
+	}
+
+	if _, ok := fieldMap[field]; !ok {
+		// not a match
+		return false
+	}
+
+	// delete the field from the map since the role is already present or we are going to add one to rule
+	delete(fieldMap, field)
+	if byteutils.ContainsBytesInSlice(rule.Roles, role) {
+		// rule already exists for the role
+		return false
+	}
+
+	return true
+}
+
+// addDefaultRules will update all default rules to include rolekey so that the document can be updated successfully
+// Note: assumes that role exists in the document already
+func (cd *CoreDocument) addDefaultRules(roleKey []byte) {
+	fieldMap := defaultRuleFieldProps()
+	for _, rule := range cd.Document.TransitionRules {
+		if !shouldAddRole(rule, roleKey, fieldMap) {
+			continue
+		}
+
+		rule.Roles = append(rule.Roles, roleKey)
+		cd.Modified = true
+	}
+
+	if len(fieldMap) < 1 {
+		// all fields are added
+		return
+	}
+
+	for _, f := range fieldMap {
+		cd.addNewTransitionRule(
+			roleKey,
+			coredocumentpb.FieldMatchType_FIELD_MATCH_TYPE_EXACT,
+			f,
+			coredocumentpb.TransitionAction_TRANSITION_ACTION_EDIT)
+	}
+}
+
+// AddTransitionRuleForAttribute adds a new rule with key as fields for the role
+// Role must be present to create a rule.
+func (cd *CoreDocument) AddTransitionRuleForAttribute(roleKey []byte, key AttrKey) (*coredocumentpb.TransitionRule, error) {
+	_, err := cd.GetRole(roleKey)
+	if err != nil {
+		return nil, err
+	}
+
+	cd.addDefaultRules(roleKey)
+	return cd.addNewTransitionRule(
+		roleKey,
+		coredocumentpb.FieldMatchType_FIELD_MATCH_TYPE_PREFIX,
+		getAttributeField(key),
+		coredocumentpb.TransitionAction_TRANSITION_ACTION_EDIT), nil
 }

--- a/documents/write_acls.go
+++ b/documents/write_acls.go
@@ -328,7 +328,8 @@ func (cd *CoreDocument) addDefaultRules(roleKey []byte) {
 }
 
 // AddTransitionRuleForAttribute adds a new rule with key as fields for the role
-//
+// FieldMatchType_FIELD_MATCH_TYPE_PREFIX will be used for the Field match for attributes
+// TransitionAction_TRANSITION_ACTION_EDIT is the default action we assign to the rule.
 // Role must be present to create a rule.
 func (cd *CoreDocument) AddTransitionRuleForAttribute(roleID []byte, key AttrKey) (*coredocumentpb.TransitionRule, error) {
 	_, err := cd.GetRole(roleID)

--- a/documents/write_acls.go
+++ b/documents/write_acls.go
@@ -297,7 +297,6 @@ func shouldAddRole(rule *coredocumentpb.TransitionRule, role []byte, fieldMap ma
 		// rule already exists for the role
 		return false
 	}
-
 	return true
 }
 
@@ -330,15 +329,15 @@ func (cd *CoreDocument) addDefaultRules(roleKey []byte) {
 
 // AddTransitionRuleForAttribute adds a new rule with key as fields for the role
 // Role must be present to create a rule.
-func (cd *CoreDocument) AddTransitionRuleForAttribute(roleKey []byte, key AttrKey) (*coredocumentpb.TransitionRule, error) {
-	_, err := cd.GetRole(roleKey)
+func (cd *CoreDocument) AddTransitionRuleForAttribute(roleID []byte, key AttrKey) (*coredocumentpb.TransitionRule, error) {
+	_, err := cd.GetRole(roleID)
 	if err != nil {
 		return nil, err
 	}
 
-	cd.addDefaultRules(roleKey)
+	cd.addDefaultRules(roleID)
 	return cd.addNewTransitionRule(
-		roleKey,
+		roleID,
 		coredocumentpb.FieldMatchType_FIELD_MATCH_TYPE_PREFIX,
 		getAttributeField(key),
 		coredocumentpb.TransitionAction_TRANSITION_ACTION_EDIT), nil

--- a/documents/write_acls.go
+++ b/documents/write_acls.go
@@ -250,29 +250,29 @@ func (cd *CoreDocument) addNewTransitionRule(roleKey []byte, matchType coredocum
 	return rule
 }
 
-var attributeCompactPrefix = [...]byte{1, 0, 0, 0, 0, 0, 0, 28}
-
-// getAttributeField creates a compact property of the attribute key
-func getAttributeField(key AttrKey) []byte {
-	return append(attributeCompactPrefix[:], key[:]...)
+// getAttributeFieldPrefix creates a compact property of the attribute key
+func getAttributeFieldPrefix(key AttrKey) []byte {
+	attrPrefix := append(CompactProperties(CDTreePrefix), []byte{0, 0, 0, 28}...)
+	return append(attrPrefix, key[:]...)
 }
 
 // defaultRuleFieldProps are the fields that every collaborator should have rule set for to update a document.
 func defaultRuleFieldProps() map[string][]byte {
 	fields := [][]byte{
-		{1, 0, 0, 0, 0, 0, 0, 3},  // current_version
-		{1, 0, 0, 0, 0, 0, 0, 4},  // next_version
-		{1, 0, 0, 0, 0, 0, 0, 16}, // previous_version
-		{1, 0, 0, 0, 0, 0, 0, 22}, // next_preimage
-		{1, 0, 0, 0, 0, 0, 0, 23}, // current_preimage
-		{1, 0, 0, 0, 0, 0, 0, 25}, // author
-		{1, 0, 0, 0, 0, 0, 0, 26}, // timestamp
+		{0, 0, 0, 3},  // current_version
+		{0, 0, 0, 4},  // next_version
+		{0, 0, 0, 16}, // previous_version
+		{0, 0, 0, 22}, // next_preimage
+		{0, 0, 0, 23}, // current_preimage
+		{0, 0, 0, 25}, // author
+		{0, 0, 0, 26}, // timestamp
 	}
 
 	fieldMap := make(map[string][]byte)
 	for _, f := range fields {
 		f := f
-		fieldMap[hexutil.Encode(f)] = f
+		cp := append(CompactProperties(CDTreePrefix), f...)
+		fieldMap[hexutil.Encode(cp)] = cp
 	}
 	return fieldMap
 }
@@ -341,6 +341,6 @@ func (cd *CoreDocument) AddTransitionRuleForAttribute(roleID []byte, key AttrKey
 	return cd.addNewTransitionRule(
 		roleID,
 		coredocumentpb.FieldMatchType_FIELD_MATCH_TYPE_PREFIX,
-		getAttributeField(key),
+		getAttributeFieldPrefix(key),
 		coredocumentpb.TransitionAction_TRANSITION_ACTION_EDIT), nil
 }

--- a/documents/write_acls.go
+++ b/documents/write_acls.go
@@ -278,7 +278,7 @@ func defaultRuleFieldProps() map[string][]byte {
 }
 
 // deleteFieldIfRoleExists checks if the role exists in the rule that has a field in the field map.
-// will update the fieldMap by deleting fields that already has the role
+// returns true if rule match type is exact, contains field in the fieldMap, and role is missing from the rule
 func deleteFieldIfRoleExists(rule *coredocumentpb.TransitionRule, role []byte, fieldMap map[string][]byte) bool {
 	field := hexutil.Encode(rule.Field)
 	if rule.MatchType != coredocumentpb.FieldMatchType_FIELD_MATCH_TYPE_EXACT {

--- a/documents/write_acls_test.go
+++ b/documents/write_acls_test.go
@@ -537,7 +537,7 @@ func TestWriteACLs_initTransitionRules(t *testing.T) {
 func roleExistsInRules(t *testing.T, cd *CoreDocument, role []byte, checkRoleCount bool, roleCount int) {
 	fieldMap := defaultRuleFieldProps()
 	for _, rule := range cd.Document.TransitionRules {
-		assert.False(t, shouldAddRole(rule, role, fieldMap))
+		assert.False(t, deleteFieldIfRoleExists(rule, role, fieldMap))
 		if checkRoleCount {
 			assert.Len(t, rule.Roles, roleCount)
 		}

--- a/httpapi/router_test.go
+++ b/httpapi/router_test.go
@@ -91,5 +91,5 @@ func TestRouter(t *testing.T) {
 	// v1 routes
 	assert.Len(t, r.Routes()[1].SubRoutes.Routes(), 25)
 	// v2 routes
-	assert.Len(t, r.Routes()[2].SubRoutes.Routes(), 10)
+	assert.Len(t, r.Routes()[2].SubRoutes.Routes(), 11)
 }

--- a/httpapi/swagger.json
+++ b/httpapi/swagger.json
@@ -2900,6 +2900,75 @@
                 }
             }
         },
+        "/v2/documents/{document_id}/transition_rules": {
+            "post": {
+                "description": "Adds a new transition rules to the document.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Documents"
+                ],
+                "summary": "Adds a transition new rules to the document.",
+                "operationId": "add_transition_rule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Hex encoded centrifuge ID of the account for the intended API action",
+                        "name": "authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Document Identifier",
+                        "name": "document_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Add Transition rules Request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "$ref": "#/definitions/pending.AddTransitionRules"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "$ref": "#/definitions/v2.TransitionRules"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "$ref": "#/definitions/httputils.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "$ref": "#/definitions/httputils.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "$ref": "#/definitions/httputils.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/v2/documents/{document_id}/versions/{version_id}": {
             "get": {
                 "description": "Returns the specific version of the document.",
@@ -3810,6 +3879,30 @@
                 }
             }
         },
+        "pending.AddTransitionRules": {
+            "type": "object",
+            "properties": {
+                "attribute_rules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/pending.AttributeRule"
+                    }
+                }
+            }
+        },
+        "pending.AttributeRule": {
+            "type": "object",
+            "properties": {
+                "key_label": {
+                    "description": "attribute key label",
+                    "type": "string"
+                },
+                "role_id": {
+                    "description": "roleID is 32 byte role ID in hex. RoleID should already be part of the document.",
+                    "type": "string"
+                }
+            }
+        },
         "transferdetails.Data": {
             "type": "object",
             "properties": {
@@ -4134,6 +4227,37 @@
                 "payload": {
                     "description": "payload to be signed in hex",
                     "type": "string"
+                }
+            }
+        },
+        "v2.TransitionRule": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string"
+                },
+                "field": {
+                    "type": "string"
+                },
+                "roles": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "rule_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2.TransitionRules": {
+            "type": "object",
+            "properties": {
+                "rules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.TransitionRule"
+                    }
                 }
             }
         },

--- a/httpapi/v2/converters.go
+++ b/httpapi/v2/converters.go
@@ -43,14 +43,21 @@ func unmarshalBody(r *http.Request, val interface{}) error {
 }
 
 func toClientRole(r *coredocumentpb.Role) Role {
-	var cs []byteutils.HexBytes
-	for _, c := range r.Collaborators {
-		c := c
-		cs = append(cs, c)
-	}
-
 	return Role{
 		ID:            r.RoleKey,
-		Collaborators: cs,
+		Collaborators: byteutils.ToHexByteSlice(r.Collaborators),
 	}
+}
+
+func toClientRules(rules []*coredocumentpb.TransitionRule) (tr TransitionRules) {
+	for _, r := range rules {
+		tr.Rules = append(tr.Rules, TransitionRule{
+			RuleID: r.RuleKey,
+			Roles:  byteutils.ToHexByteSlice(r.Roles),
+			Field:  r.Field,
+			Action: coredocumentpb.TransitionAction_name[int32(r.Action)],
+		})
+	}
+
+	return tr
 }

--- a/httpapi/v2/handler.go
+++ b/httpapi/v2/handler.go
@@ -29,4 +29,5 @@ func Register(ctx map[string]interface{}, r chi.Router) {
 	r.Get("/documents/{"+coreapi.DocumentIDParam+"}/roles/{"+RoleIDParam+"}", h.GetRole)
 	r.Post("/documents/{"+coreapi.DocumentIDParam+"}/roles", h.AddRole)
 	r.Patch("/documents/{"+coreapi.DocumentIDParam+"}/roles/{"+RoleIDParam+"}", h.UpdateRole)
+	r.Post("/documents/{"+coreapi.DocumentIDParam+"}/transition_rules", h.AddTransitionRules)
 }

--- a/httpapi/v2/handler_test.go
+++ b/httpapi/v2/handler_test.go
@@ -13,5 +13,5 @@ func TestRegister(t *testing.T) {
 	r := chi.NewRouter()
 	ctx := map[string]interface{}{BootstrappedService: Service{}}
 	Register(ctx, r)
-	assert.Len(t, r.Routes(), 10)
+	assert.Len(t, r.Routes(), 11)
 }

--- a/httpapi/v2/rules.go
+++ b/httpapi/v2/rules.go
@@ -1,0 +1,73 @@
+package v2
+
+import (
+	"net/http"
+
+	"github.com/centrifuge/go-centrifuge/httpapi/coreapi"
+	"github.com/centrifuge/go-centrifuge/pending"
+	"github.com/centrifuge/go-centrifuge/utils/byteutils"
+	"github.com/centrifuge/go-centrifuge/utils/httputils"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/go-chi/chi"
+	"github.com/go-chi/render"
+)
+
+// TransitionRule holds the ruleID, roles, and fields in hex format
+type TransitionRule struct {
+	RuleID byteutils.HexBytes   `json:"rule_id" swaggertype:"primitive,string"`
+	Roles  []byteutils.HexBytes `json:"roles" swaggertype:"array,string"`
+	Field  byteutils.HexBytes   `json:"field" swaggertype:"primitive,string"`
+	Action string               `json:"action"`
+}
+
+// TransitionRules holds the list of transition rule.
+type TransitionRules struct {
+	Rules []TransitionRule `json:"rules"`
+}
+
+// AddTransitionRules adds a new transition rules to the document.
+// @summary Adds a transition new rules to the document.
+// @description Adds a new transition rules to the document.
+// @id add_transition_rule
+// @tags Documents
+// @param authorization header string true "Hex encoded centrifuge ID of the account for the intended API action"
+// @param document_id path string true "Document Identifier"
+// @param body body pending.AddTransitionRules true "Add Transition rules Request"
+// @produce json
+// @Failure 403 {object} httputils.HTTPError
+// @Failure 400 {object} httputils.HTTPError
+// @Failure 404 {object} httputils.HTTPError
+// @success 200 {object} v2.TransitionRules
+// @router /v2/documents/{document_id}/transition_rules [post]
+func (h handler) AddTransitionRules(w http.ResponseWriter, r *http.Request) {
+	var err error
+	var code int
+	defer httputils.RespondIfError(&code, &err, w, r)
+
+	docID, err := hexutil.Decode(chi.URLParam(r, coreapi.DocumentIDParam))
+	if err != nil {
+		code = http.StatusBadRequest
+		log.Error(err)
+		err = coreapi.ErrInvalidDocumentID
+		return
+	}
+
+	ctx := r.Context()
+	var addRules pending.AddTransitionRules
+	err = unmarshalBody(r, &addRules)
+	if err != nil {
+		code = http.StatusBadRequest
+		log.Error(err)
+		return
+	}
+
+	rules, err := h.srv.AddTransitionRules(ctx, docID, addRules)
+	if err != nil {
+		code = http.StatusBadRequest
+		log.Error(err)
+		return
+	}
+
+	render.Status(r, http.StatusOK)
+	render.JSON(w, r, toClientRules(rules))
+}

--- a/httpapi/v2/rules_test.go
+++ b/httpapi/v2/rules_test.go
@@ -1,0 +1,94 @@
+// +build unit
+
+package v2
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	coredocumentpb "github.com/centrifuge/centrifuge-protobufs/gen/go/coredocument"
+	"github.com/centrifuge/go-centrifuge/errors"
+	"github.com/centrifuge/go-centrifuge/httpapi/coreapi"
+	"github.com/centrifuge/go-centrifuge/pending"
+	"github.com/centrifuge/go-centrifuge/utils"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/go-chi/chi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestHandler_AddTransitionRules(t *testing.T) {
+	getHTTPReqAndResp := func(ctx context.Context, b io.Reader) (*httptest.ResponseRecorder, *http.Request) {
+		return httptest.NewRecorder(), httptest.NewRequest("post", "/documents/{document_id}/transition_rules", b).WithContext(ctx)
+	}
+
+	// invalid doc id
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Keys = make([]string, 1, 1)
+	rctx.URLParams.Values = make([]string, 1, 1)
+	rctx.URLParams.Keys[0] = coreapi.DocumentIDParam
+	rctx.URLParams.Values[0] = "some invalid id"
+	ctx := context.WithValue(context.Background(), chi.RouteCtxKey, rctx)
+	w, r := getHTTPReqAndResp(ctx, nil)
+	h := handler{}
+	h.AddTransitionRules(w, r)
+	assert.Equal(t, w.Code, http.StatusBadRequest)
+	assert.Contains(t, w.Body.String(), coreapi.ErrInvalidDocumentID.Error())
+
+	type attrRule struct {
+		KeyLabel string `json:"key_label"`
+		RoleID   string `json:"role_id"`
+	}
+
+	var rule struct {
+		AttributeRules []attrRule `json:"attribute_rules"`
+	}
+
+	// bad roleID
+	rule.AttributeRules = make([]attrRule, 1)
+	rule.AttributeRules[0].RoleID = ""
+	rule.AttributeRules[0].KeyLabel = "test"
+	d, err := json.Marshal(rule)
+	assert.NoError(t, err)
+	docID := utils.RandomSlice(32)
+	rctx.URLParams.Values[0] = hexutil.Encode(docID)
+	w, r = getHTTPReqAndResp(ctx, bytes.NewReader(d))
+	h.AddTransitionRules(w, r)
+	assert.Equal(t, w.Code, http.StatusBadRequest)
+	assert.Contains(t, w.Body.String(), "empty hex string")
+
+	// failed to add rule
+	roleID := utils.RandomSlice(32)
+	rule.AttributeRules[0].RoleID = hexutil.Encode(roleID)
+	d, err = json.Marshal(rule)
+	assert.NoError(t, err)
+	psrv := new(pending.MockService)
+	psrv.On("AddTransitionRules", mock.Anything, docID, mock.Anything).
+		Return(nil, errors.New("failed to add rule")).Once()
+	h.srv.pendingDocSrv = psrv
+	w, r = getHTTPReqAndResp(ctx, bytes.NewReader(d))
+	h.AddTransitionRules(w, r)
+	assert.Equal(t, w.Code, http.StatusBadRequest)
+	assert.Contains(t, w.Body.String(), "failed to add rule")
+
+	// success )
+	psrv.On("AddTransitionRules", mock.Anything, docID, mock.Anything).
+		Return([]*coredocumentpb.TransitionRule{
+			{
+				RuleKey:   utils.RandomSlice(32),
+				Roles:     [][]byte{roleID},
+				MatchType: coredocumentpb.FieldMatchType_FIELD_MATCH_TYPE_PREFIX,
+				Field:     utils.RandomSlice(10),
+				Action:    coredocumentpb.TransitionAction_TRANSITION_ACTION_EDIT,
+			},
+		}, nil).Once()
+	w, r = getHTTPReqAndResp(ctx, bytes.NewReader(d))
+	h.AddTransitionRules(w, r)
+	assert.Equal(t, w.Code, http.StatusOK)
+	psrv.AssertExpectations(t)
+}

--- a/httpapi/v2/service.go
+++ b/httpapi/v2/service.go
@@ -66,3 +66,9 @@ func (s Service) GetRole(ctx context.Context, docID, roleID []byte) (*coredocume
 func (s Service) UpdateRole(ctx context.Context, docID, roleID []byte, dids []identity.DID) (*coredocumentpb.Role, error) {
 	return s.pendingDocSrv.UpdateRole(ctx, docID, roleID, dids)
 }
+
+// AddTransitionRules adds new rules to the document
+func (s Service) AddTransitionRules(
+	ctx context.Context, docID []byte, addRules pending.AddTransitionRules) ([]*coredocumentpb.TransitionRule, error) {
+	return s.pendingDocSrv.AddTransitionRules(ctx, docID, addRules)
+}

--- a/pending/test_pending.go
+++ b/pending/test_pending.go
@@ -85,3 +85,9 @@ func (m *MockService) UpdateRole(ctx context.Context, docID, roleID []byte, coll
 	r, _ := args.Get(0).(*coredocumentpb.Role)
 	return r, args.Error(1)
 }
+
+func (m *MockService) AddTransitionRules(ctx context.Context, docID []byte, addRule AddTransitionRules) ([]*coredocumentpb.TransitionRule, error) {
+	args := m.Called(ctx, docID, addRule)
+	r, _ := args.Get(0).([]*coredocumentpb.TransitionRule)
+	return r, args.Error(1)
+}

--- a/testworld/configs/testing.json
+++ b/testworld/configs/testing.json
@@ -1,6 +1,6 @@
 {
   "run_network": true,
-  "run_migrations": true,
+  "run_migrations": false,
   "network" : "testing",
   "eth_node_url": "ws://127.0.0.1:9546",
   "eth_account_key_path": "../build/scripts/test-dependencies/test-ethereum/migrateAccount.json",

--- a/testworld/configs/testing.json
+++ b/testworld/configs/testing.json
@@ -1,6 +1,6 @@
 {
   "run_network": true,
-  "run_migrations": false,
+  "run_migrations": true,
   "network" : "testing",
   "eth_node_url": "ws://127.0.0.1:9546",
   "eth_account_key_path": "../build/scripts/test-dependencies/test-ethereum/migrateAccount.json",

--- a/testworld/httputils.go
+++ b/testworld/httputils.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/centrifuge/go-centrifuge/httpapi/coreapi"
+	v2 "github.com/centrifuge/go-centrifuge/httpapi/v2"
 	"github.com/gavv/httpexpect"
 	"github.com/stretchr/testify/assert"
 )
@@ -207,8 +208,8 @@ func commitDocument(e *httpexpect.Expect, auth string, documentType string, stat
 func updateCoreAPIDocument(e *httpexpect.Expect, auth string, documentType string, docID string, status int, payload map[string]interface{}) *httpexpect.Object {
 	obj := addCommonHeaders(e.PUT("/v1/"+documentType+"/"+docID), auth).
 		WithJSON(payload).
-		Expect().Status(status).JSON().Object()
-	return obj
+		Expect().Status(status)
+	return obj.JSON().Object()
 }
 
 func createFunding(e *httpexpect.Expect, auth string, identifier string, status int, payload map[string]interface{}) *httpexpect.Object {
@@ -503,4 +504,18 @@ func updateRole(e *httpexpect.Expect, auth, docID, roleID string, collaborators 
 		"collaborators": collaborators,
 	}).Expect().Status(status).JSON().Object()
 	return objPost
+}
+
+func addTransitionRules(e *httpexpect.Expect, auth, docID string, payload map[string][]map[string]string, status int) *httpexpect.Object {
+	objPost := addCommonHeaders(e.POST("/v2/documents/"+docID+"/transition_rules"), auth).WithJSON(
+		payload).Expect().Status(status).JSON().Object()
+	return objPost
+}
+
+func parseRules(t *testing.T, obj *httpexpect.Object) v2.TransitionRules {
+	d, err := json.Marshal(obj.Raw())
+	assert.NoError(t, err)
+	var tr v2.TransitionRules
+	assert.NoError(t, json.Unmarshal(d, &tr))
+	return tr
 }

--- a/testworld/rules_test.go
+++ b/testworld/rules_test.go
@@ -1,0 +1,97 @@
+// +build testworld
+
+package testworld
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/centrifuge/go-centrifuge/httpapi/coreapi"
+	"github.com/centrifuge/go-centrifuge/utils"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupTransitionRuleForCharlie(t *testing.T) (string, string) {
+	alice := doctorFord.getHostTestSuite(t, "Alice")
+	bob := doctorFord.getHostTestSuite(t, "Bob")
+	charlie := doctorFord.getHostTestSuite(t, "Charlie")
+
+	// Alice prepares document to share with Bob
+	docPayload := genericCoreAPICreate([]string{bob.id.String()})
+	res := createDocumentV2(alice.httpExpect, alice.id.String(), "documents", http.StatusCreated, docPayload)
+	status := getDocumentStatus(t, res)
+	assert.Equal(t, status, "pending")
+	docID := getDocumentIdentifier(t, res)
+	roleID := utils.RandomSlice(32)
+	payload := map[string][]map[string]string{
+		"attribute_rules": {
+			{
+				"key_label": "oracle1",
+				"role_id":   hexutil.Encode(roleID),
+			},
+		},
+	}
+
+	// no role
+	obj := addTransitionRules(alice.httpExpect, alice.id.String(), docID, payload, http.StatusBadRequest)
+	assert.Contains(t, obj.Path("$.message").String().Raw(), "role doesn't exist")
+
+	// create role
+	obj = addRole(alice.httpExpect, alice.id.String(), docID, hexutil.Encode(roleID), []string{charlie.id.String()}, http.StatusOK)
+	r, cs := parseRole(obj)
+	assert.Equal(t, r, hexutil.Encode(roleID))
+	assert.Contains(t, cs, strings.ToLower(charlie.id.String()))
+
+	// add transition rules
+	obj = addTransitionRules(alice.httpExpect, alice.id.String(), docID, payload, http.StatusOK)
+	tr := parseRules(t, obj)
+	assert.Len(t, tr.Rules, 1)
+
+	// commit document
+	res = commitDocument(alice.httpExpect, alice.id.String(), "documents", http.StatusAccepted, docID)
+	txID := getTransactionID(t, res)
+	status, message := getTransactionStatusAndMessage(alice.httpExpect, alice.id.String(), txID)
+	assert.Equal(t, status, "success", message)
+	getGenericDocumentAndCheck(t, alice.httpExpect, alice.id.String(), docID, nil, createAttributes())
+	// pending document should fail
+	getV2DocumentWithStatus(alice.httpExpect, alice.id.String(), docID, "pending", http.StatusNotFound)
+	// committed should be successful
+	getV2DocumentWithStatus(alice.httpExpect, alice.id.String(), docID, "committed", http.StatusOK)
+	// Bob should have the document
+	getGenericDocumentAndCheck(t, bob.httpExpect, bob.id.String(), docID, nil, createAttributes())
+	return docID, hexutil.Encode(roleID)
+}
+
+func TestTransitionRules(t *testing.T) {
+	//alice := doctorFord.getHostTestSuite(t, "Alice")
+	//bob := doctorFord.getHostTestSuite(t, "Bob")
+	charlie := doctorFord.getHostTestSuite(t, "Charlie")
+	docID, _ := setupTransitionRuleForCharlie(t)
+
+	// charlie updates the document with wrong attr key and tries to get full access
+	p := genericCoreAPIUpdate([]string{charlie.id.String()})
+	res := updateCoreAPIDocument(charlie.httpExpect, charlie.id.String(), "documents", docID, http.StatusAccepted, p)
+	txID := getTransactionID(t, res)
+	status, _ := getTransactionStatusAndMessage(charlie.httpExpect, charlie.id.String(), txID)
+	if status == "success" {
+		t.Error("document should not be updated")
+	}
+
+	// charlie updates the document with right attribute
+	docID, _ = setupTransitionRuleForCharlie(t)
+	p = genericCoreAPICreate(nil)
+	p["attributes"] = coreapi.AttributeMapRequest{
+		"oracle1": coreapi.AttributeRequest{
+			Type:  "decimal",
+			Value: "100.001",
+		},
+	}
+	res = updateCoreAPIDocument(charlie.httpExpect, charlie.id.String(), "documents", docID, http.StatusAccepted, p)
+	txID = getTransactionID(t, res)
+	status, _ = getTransactionStatusAndMessage(charlie.httpExpect, charlie.id.String(), txID)
+	if status != "success" {
+		t.Error("document should be updated")
+	}
+}

--- a/utils/byteutils/bytes.go
+++ b/utils/byteutils/bytes.go
@@ -138,6 +138,16 @@ func (h *HexBytes) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// ToHexByteSlice converts slicee of slice of bytes to slice of HexBytes
+func ToHexByteSlice(l [][]byte) (hb []HexBytes) {
+	for _, b := range l {
+		b := b
+		hb = append(hb, b)
+	}
+
+	return hb
+}
+
 // String returns HexBytes in string format.
 func (h HexBytes) String() string {
 	return hexutil.Encode(h)


### PR DESCRIPTION
Closes #1347

This PR adds the capability to add transition rules specific attributes in the document. Testworld tests help in using them.