### PR TITLE
Validate configuration ethereum.nodeURL

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -17,7 +17,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/centrifuge/centrifuge-protobufs/gen/go/coredocument"
 	"github.com/centrifuge/go-centrifuge/errors"
 	"github.com/centrifuge/go-centrifuge/resources"
 	"github.com/centrifuge/go-centrifuge/storage"
@@ -30,6 +29,12 @@ import (
 )
 
 var log = logging.Logger("config")
+
+var allowedURLScheme = map[string]struct{}{
+	"http":  {},
+	"https": {},
+	"ws":    {},
+}
 
 // AccountHeaderKey is used as key for the account identity in the context.ContextWithValue.
 var AccountHeaderKey struct{}
@@ -695,7 +700,9 @@ func validateURL(u string) string {
 
 	if parsedURL.Scheme == "" {
 		parsedURL.Scheme = defaultURLScheme
-	} else if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+	}
+
+	if _, ok := allowedURLScheme[parsedURL.Scheme]; !ok {
 		log.Fatalf("error: url scheme %s is not allowed", parsedURL.Scheme)
 	}
 

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
+	"net/url"
 	"os"
 	"reflect"
 	"strings"
@@ -40,6 +41,8 @@ type ContractName string
 type ContractOp string
 
 const (
+	defaultURLPrefix = "https"
+
 	// AnchorRepo is the contract name for AnchorRepo
 	AnchorRepo ContractName = "anchorRepository"
 
@@ -651,7 +654,7 @@ func CreateConfigFile(args map[string]interface{}) (*viper.Viper, error) {
 	if p2pConnectTimeout != "" {
 		v.Set("p2p.connectTimeout", p2pConnectTimeout)
 	}
-	v.Set("ethereum.nodeURL", ethNodeURL)
+	v.Set("ethereum.nodeURL", parseURL(ethNodeURL))
 	v.Set("ethereum.accounts.main.key", "")
 	v.Set("ethereum.accounts.main.password", "")
 	v.Set("centChain.nodeURL", centChainURL)
@@ -682,4 +685,17 @@ func CreateConfigFile(args map[string]interface{}) (*viper.Viper, error) {
 
 func (c *configuration) SetupSmartContractAddresses(network string, smartContractAddresses *SmartContractAddresses) {
 	c.v.Set("networks."+network+".contractAddresses.identityFactory", smartContractAddresses.IdentityFactoryAddr)
+}
+
+func parseURL(u string) string {
+	parsedURL, err := url.Parse(u)
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+
+	if parsedURL.Scheme == "" {
+		parsedURL.Scheme = defaultURLPrefix
+	}
+
+	return parsedURL.String()
 }

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/centrifuge/centrifuge-protobufs/gen/go/coredocument"
 	"github.com/centrifuge/go-centrifuge/errors"
 	"github.com/centrifuge/go-centrifuge/resources"
 	"github.com/centrifuge/go-centrifuge/storage"

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -695,6 +695,8 @@ func validateURL(u string) string {
 
 	if parsedURL.Scheme == "" {
 		parsedURL.Scheme = defaultURLPrefix
+	} else if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		log.Fatalf("error: url scheme %s is not allowed", parsedURL.Scheme)
 	}
 
 	return parsedURL.String()

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -41,7 +41,7 @@ type ContractName string
 type ContractOp string
 
 const (
-	defaultURLPrefix = "https"
+	defaultURLScheme = "https"
 
 	// AnchorRepo is the contract name for AnchorRepo
 	AnchorRepo ContractName = "anchorRepository"
@@ -694,7 +694,7 @@ func validateURL(u string) string {
 	}
 
 	if parsedURL.Scheme == "" {
-		parsedURL.Scheme = defaultURLPrefix
+		parsedURL.Scheme = defaultURLScheme
 	} else if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
 		log.Fatalf("error: url scheme %s is not allowed", parsedURL.Scheme)
 	}

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -654,7 +654,7 @@ func CreateConfigFile(args map[string]interface{}) (*viper.Viper, error) {
 	if p2pConnectTimeout != "" {
 		v.Set("p2p.connectTimeout", p2pConnectTimeout)
 	}
-	v.Set("ethereum.nodeURL", parseURL(ethNodeURL))
+	v.Set("ethereum.nodeURL", validateURL(ethNodeURL))
 	v.Set("ethereum.accounts.main.key", "")
 	v.Set("ethereum.accounts.main.password", "")
 	v.Set("centChain.nodeURL", centChainURL)
@@ -687,7 +687,7 @@ func (c *configuration) SetupSmartContractAddresses(network string, smartContrac
 	c.v.Set("networks."+network+".contractAddresses.identityFactory", smartContractAddresses.IdentityFactoryAddr)
 }
 
-func parseURL(u string) string {
+func validateURL(u string) string {
 	parsedURL, err := url.Parse(u)
 	if err != nil {
 		log.Fatalf("error: %v", err)

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -592,7 +592,8 @@ func (c *configuration) initializeViper() {
 
 func (c *configuration) validateURLs(keys []string) error {
 	for _, key := range keys {
-		value, err := validateURL(c.v.Get(key).(string))
+		value, _ := c.v.Get(key).(string)
+		value, err := validateURL(value)
 		if err != nil {
 			return err
 		}
@@ -612,7 +613,10 @@ func CreateConfigFile(args map[string]interface{}) (*viper.Viper, error) {
 	accountKeyPath := args["accountKeyPath"].(string)
 	accountPassword := args["accountPassword"].(string)
 	network := args["network"].(string)
-	ethNodeURL := args["ethNodeURL"].(string)
+	ethNodeURL, err := validateURL(args["ethNodeURL"].(string))
+	if err != nil {
+		return nil, err
+	}
 	bootstraps := args["bootstraps"].([]string)
 	apiPort := args["apiPort"].(int64)
 	p2pPort := args["p2pPort"].(int64)
@@ -621,6 +625,10 @@ func CreateConfigFile(args map[string]interface{}) (*viper.Viper, error) {
 	apiHost := args["apiHost"].(string)
 	webhookURL, _ := args["webhookURL"].(string)
 	centChainURL, _ := args["centChainURL"].(string)
+	centChainURL, err = validateURL(centChainURL)
+	if err != nil {
+		return nil, err
+	}
 	centChainID, _ := args["centChainID"].(string)
 	centChainSecret, _ := args["centChainSecret"].(string)
 	centChainAddr, _ := args["centChainAddr"].(string)

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -59,3 +59,43 @@ func TestConfiguration_CreateConfigFile(t *testing.T) {
 
 	assert.NoError(t, os.RemoveAll(targetDir))
 }
+
+func TestValidateUrl(t *testing.T) {
+	testCases := []struct {
+		name string
+		url string
+		expectedHasErr bool
+		expectedURL string
+	} {
+		{
+			name: "valid url",
+			url: "http://rinkeby.infura.io/v3",
+			expectedHasErr: false,
+			expectedURL: "http://rinkeby.infura.io/v3",
+		},
+		{
+			name: "without scheme",
+			url: "rinkeby.infura.io/v3/",
+			expectedHasErr: false,
+			expectedURL: "https://rinkeby.infura.io/v3/",
+		},
+		{
+			name: "not allowed scheme",
+			url: "ftp://rinkeby.infura.io/v3/",
+			expectedHasErr: true,
+			expectedURL: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			url, err := validateURL(testCase.url)
+			if testCase.expectedHasErr {
+				assert.NotNil(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectedURL, url)
+		})
+	}
+}


### PR DESCRIPTION
Hello 👋 , this is my first PR in go-centrifuge project. I picked [issue #1204](https://github.com/centrifuge/go-centrifuge/issues/1204) which is labeled as the good first issue and tried to work it out.

As described in the issue, etherNodeURL needs a prefix and by default should be set to https. The validateURL adds the prefix if necessary and checks if the schema is either http or https.

