### PR TITLE
update notifications with different types

### DIFF
--- a/build/scripts/push_to_swagger.sh
+++ b/build/scripts/push_to_swagger.sh
@@ -2,11 +2,11 @@
 
 # push the swagger api json to swagger hub
 echo "pushing swagger.json to SwaggerHub"
-VERSION=`jq -c '.info.version' httpapi/swagger.json -r`
+VERSION=$(jq -c '.info.version' http/swagger.json -r)
 
-curl -i -X POST \
+curl -f -i -X POST \
   https://api.swaggerhub.com/apis/centrifuge.io/cent-node?version=${VERSION} \
   -H "Authorization: $SWAGGER_API_KEY" \
-  -H "Content-Type: application/json" -d @./httpapi/swagger.json
+  -H "Content-Type: application/json" -d @./http/swagger.json
 
 exit $?

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,8 +2,8 @@ ignore:
   - identity/ideth/factory_contract.go
   - identity/ideth/identity_contract.go
   - "**/mocks.go"
-  - migrations/files/**/*
-  - testworld/**/*
-  - build/**/*
-  - resources/**/*
-  - testingutils/**/*
+  - migrations/files
+  - testworld
+  - build
+  - resources
+  - testingutils

--- a/documents/service.go
+++ b/documents/service.go
@@ -270,18 +270,19 @@ func (s service) ReceiveAnchoredDocument(ctx context.Context, doc Document, coll
 	}
 
 	notificationMsg := notification.Message{
-		EventType:    notification.ReceivedPayload,
-		AccountID:    did.String(),
-		FromID:       hexutil.Encode(collaborator[:]),
-		ToID:         did.String(),
-		Recorded:     time.Now().UTC(),
-		DocumentType: doc.DocumentType(),
-		DocumentID:   hexutil.Encode(doc.ID()),
+		EventType:  notification.EventTypeDocument,
+		RecordedAt: time.Now().UTC(),
+		Document: &notification.DocumentMessage{
+			ID:        doc.ID(),
+			VersionID: doc.CurrentVersion(),
+			From:      collaborator[:],
+			To:        did[:],
+		},
 	}
 
 	// async so that we don't return an error as the p2p reply
 	go func() {
-		_, err = s.notifier.Send(ctx, notificationMsg)
+		err = s.notifier.Send(ctx, notificationMsg)
 		if err != nil {
 			log.Error(err)
 		}

--- a/http/router.go
+++ b/http/router.go
@@ -33,7 +33,7 @@ func Router(ctx context.Context) (*chi.Mux, error) {
 	r := chi.NewRouter()
 	cctx, ok := ctx.Value(bootstrap.NodeObjRegistry).(map[string]interface{})
 	if !ok {
-		return nil, errors.New("failed to get %T", bootstrap.NodeObjRegistry)
+		return nil, errors.New("failed to get %s", bootstrap.NodeObjRegistry)
 	}
 
 	cfg, ok := cctx[bootstrap.BootstrappedConfig].(Config)

--- a/http/router.go
+++ b/http/router.go
@@ -33,7 +33,7 @@ func Router(ctx context.Context) (*chi.Mux, error) {
 	r := chi.NewRouter()
 	cctx, ok := ctx.Value(bootstrap.NodeObjRegistry).(map[string]interface{})
 	if !ok {
-		return nil, errors.New("failed to get %s", bootstrap.NodeObjRegistry)
+		return nil, errors.New("failed to get %T", bootstrap.NodeObjRegistry)
 	}
 
 	cfg, ok := cctx[bootstrap.BootstrappedConfig].(Config)

--- a/http/swagger.json
+++ b/http/swagger.json
@@ -2367,37 +2367,71 @@
                 }
             }
         },
+        "notification.DocumentMessage": {
+            "type": "object",
+            "properties": {
+                "from": {
+                    "description": "document received from",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "document identifier",
+                    "type": "string"
+                },
+                "to": {
+                    "description": "document sent to",
+                    "type": "string"
+                },
+                "version_id": {
+                    "description": "version identifier",
+                    "type": "string"
+                }
+            }
+        },
+        "notification.JobMessage": {
+            "type": "object",
+            "properties": {
+                "desc": {
+                    "description": "description of the job",
+                    "type": "string"
+                },
+                "finished_at": {
+                    "description": "job finished at",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "job identifier",
+                    "type": "string"
+                },
+                "owner": {
+                    "description": "job owner",
+                    "type": "string"
+                },
+                "valid_until": {
+                    "description": "validity of the job",
+                    "type": "string"
+                }
+            }
+        },
         "notification.Message": {
             "type": "object",
             "properties": {
-                "account_id": {
-                    "description": "account_id is the account associated to webhook",
-                    "type": "string"
-                },
-                "document_id": {
-                    "type": "string"
-                },
-                "document_type": {
-                    "type": "string"
+                "document": {
+                    "description": "Document contains recently received document. Ensure event type is document",
+                    "$ref": "#/definitions/notification.DocumentMessage"
                 },
                 "event_type": {
-                    "type": "integer"
+                    "type": "string",
+                    "enum": [
+                        "job",
+                        "document"
+                    ]
                 },
-                "from_id": {
-                    "description": "from_id if provided, original trigger of the event",
-                    "type": "string"
+                "job": {
+                    "description": "Job contains jobs specific details. Ensure event type is job",
+                    "$ref": "#/definitions/notification.JobMessage"
                 },
-                "message": {
-                    "type": "string"
-                },
-                "recorded": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "to_id": {
-                    "description": "to_id if provided, final destination of the event",
+                "recorded_at": {
                     "type": "string"
                 }
             }

--- a/identity/ideth/service.go
+++ b/identity/ideth/service.go
@@ -148,7 +148,7 @@ func (s service) AddKey(ctx context.Context, key identity.Key) error {
 	}
 
 	opts.GasLimit = s.config.GetEthereumGasLimit(config.IDAddKey)
-	log.Info("Add key to identity contract %s", did.ToAddress().String())
+	log.Infof("Add key to identity contract %s\n", did.ToAddress().String())
 	err = s.submitAndWait(did, contract.AddKey, opts, key.GetKey(), key.GetPurpose(), key.GetType())
 	if err != nil {
 		return fmt.Errorf("failed to add key to contact: %w", err)

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -96,7 +96,7 @@ func (d *dispatcher) Start(ctx context.Context, wg *sync.WaitGroup, startupErr c
 	// start job finished notifier
 	wg.Add(1)
 	go func() {
-		initJobWebhooks(ctx, d, wg, startupErr)
+		initJobWebhooks(ctx, d, wg)
 	}()
 
 	// start dispatcher
@@ -108,17 +108,17 @@ func (d *dispatcher) Name() string {
 	return "Jobs Dispatcher"
 }
 
-func initJobWebhooks(ctx context.Context, dispatcher *dispatcher, wg *sync.WaitGroup, startupErr chan<- error) {
+func initJobWebhooks(ctx context.Context, dispatcher *dispatcher, wg *sync.WaitGroup) {
 	defer wg.Done()
 	cctx, ok := ctx.Value(bootstrap.NodeObjRegistry).(map[string]interface{})
 	if !ok {
-		startupErr <- errors.New("failed to get %s", bootstrap.NodeObjRegistry)
+		log.Debug("jobs: failed to find Node registry")
 		return
 	}
 
 	configSrv, ok := cctx[config.BootstrappedConfigStorage].(config.Service)
 	if !ok {
-		startupErr <- errors.New("failed to get %s", config.BootstrappedConfigStorage)
+		log.Debug("jobs: failed to find config service")
 		return
 	}
 

--- a/jobs/jobs_test.go
+++ b/jobs/jobs_test.go
@@ -3,13 +3,21 @@
 package jobs
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/centrifuge/go-centrifuge/bootstrap"
+	"github.com/centrifuge/go-centrifuge/config"
 	"github.com/centrifuge/go-centrifuge/identity"
+	"github.com/centrifuge/go-centrifuge/notification"
 	"github.com/centrifuge/go-centrifuge/storage/leveldb"
 	"github.com/centrifuge/go-centrifuge/utils"
 	"github.com/centrifuge/gocelery/v2"
@@ -17,14 +25,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDispatcher(t *testing.T) {
-	acc := identity.NewDID(common.BytesToAddress(utils.RandomSlice(20)))
-	job := gocelery.NewRunnerFuncJob("Test", "add", []interface{}{1, 2}, nil, time.Now())
-	db, err := leveldb.NewLevelDBStorage(leveldb.GetRandomTestStoragePath())
-	assert.NoError(t, err)
-	d, err := NewDispatcher(db, 10, 2*time.Minute)
-	assert.NoError(t, err)
-	ctx, cancel := context.WithCancel(context.Background())
+func TestDispatch(t *testing.T) {
+	t.Run("With webhook", func(t *testing.T) {
+		t.Parallel()
+		dispatch(t, true)
+	})
+
+	t.Run("Without webhook", func(t *testing.T) {
+		t.Parallel()
+		dispatch(t, false)
+	})
+}
+
+func dispatch(t *testing.T, webhook bool) {
+	ctx, s, resChan, did, d, mockAssert := setup(t, webhook)
+	go s.ListenAndServe()
+	defer s.Close()
+
+	ctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
@@ -34,17 +52,21 @@ func TestDispatcher(t *testing.T) {
 		return args[0].(int) + args[1].(int), nil
 	}))
 
-	_, err = d.Job(acc, job.ID)
+	job := gocelery.NewRunnerFuncJob("Test", "add", []interface{}{1, 2}, nil, time.Now())
+	_, err := d.Job(did, job.ID)
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, gocelery.ErrNotFound))
 
-	res, err := d.Dispatch(acc, job)
+	res, err := d.Dispatch(did, job)
 	assert.NoError(t, err)
+	owner, err := d.(*dispatcher).jobOwner(job.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, did, owner)
 	r, err := res.Await(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, r)
 
-	j, err := d.Job(acc, job.ID)
+	j, err := d.Job(did, job.ID)
 	assert.NoError(t, err)
 	assert.True(t, j.HasCompleted())
 	assert.True(t, j.IsSuccessful())
@@ -53,9 +75,68 @@ func TestDispatcher(t *testing.T) {
 	assert.Equal(t, j.LastTask().Tries, uint(1))
 	assert.Equal(t, j.LastTask().Result, 3)
 
-	nr, err := d.Result(acc, job.ID)
+	nr, err := d.Result(did, job.ID)
 	assert.NoError(t, err)
 	r, err = nr.Await(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, r)
+
+	if webhook {
+		assert.True(t, bytes.Equal(job.ID[:], <-resChan))
+	} else {
+		assert.Len(t, resChan, 0)
+	}
+	mockAssert()
+}
+
+func setup(t *testing.T, webhook bool) (context.Context, *http.Server, chan []byte, identity.DID, Dispatcher, func()) {
+	did := identity.NewDID(common.BytesToAddress(utils.RandomSlice(20)))
+	db, err := leveldb.NewLevelDBStorage(leveldb.GetRandomTestStoragePath())
+	assert.NoError(t, err)
+	d, err := NewDispatcher(db, 10, 2*time.Minute)
+	assert.NoError(t, err)
+	resChan := make(chan []byte)
+	s := prepareServer(t, resChan)
+	url := ""
+	if webhook {
+		url = fmt.Sprintf("http://%s/webhook", s.Addr)
+	}
+	ctx, assert := getContext(t, did, url)
+	return ctx, s, resChan, did, d, assert
+}
+
+func prepareServer(t *testing.T, resChan chan<- []byte) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/webhook", func(writer http.ResponseWriter, request *http.Request) {
+		var resp notification.Message
+		defer request.Body.Close()
+		data, err := ioutil.ReadAll(request.Body)
+		assert.NoError(t, err)
+
+		err = json.Unmarshal(data, &resp)
+		assert.NoError(t, err)
+		writer.Write([]byte("success"))
+		resChan <- resp.Job.ID
+	})
+
+	addr, _, err := utils.GetFreeAddrPort()
+	assert.NoError(t, err)
+	server := &http.Server{Addr: addr, Handler: mux}
+	return server
+}
+
+func getContext(t *testing.T, did identity.DID, url string) (context.Context, func()) {
+	cfgSrv := new(config.MockService)
+	acc := new(config.MockAccount)
+	acc.On("GetReceiveEventNotificationEndpoint").Return(url).Once()
+	cfgSrv.On("GetAccount", did[:]).Return(acc, nil).Once()
+	ctx := context.WithValue(
+		context.Background(),
+		bootstrap.NodeObjRegistry, map[string]interface{}{config.BootstrappedConfigStorage: cfgSrv})
+	assert := func() {
+		cfgSrv.AssertExpectations(t)
+		acc.AssertExpectations(t)
+	}
+
+	return ctx, assert
 }

--- a/notification/notification.go
+++ b/notification/notification.go
@@ -25,11 +25,11 @@ const (
 )
 
 type JobMessage struct {
-	ID         byteutils.HexBytes `json:"id" swaggertype:"primitive,string"`    // jobID
+	ID         byteutils.HexBytes `json:"id" swaggertype:"primitive,string"`    // job identifier
 	Owner      byteutils.HexBytes `json:"owner" swaggertype:"primitive,string"` // job owner
-	Desc       string             `json:"desc"`                                 // description if the job
+	Desc       string             `json:"desc"`                                 // description of the job
 	ValidUntil time.Time          `json:"valid_until"`                          // validity of the job
-	FinishedAt time.Time          `json:"finished_at"`                          // Job finished at
+	FinishedAt time.Time          `json:"finished_at"`                          // job finished at
 }
 
 type DocumentMessage struct {
@@ -41,11 +41,14 @@ type DocumentMessage struct {
 
 // Message is the payload used to send the notifications.
 type Message struct {
-	EventType  EventType        `json:"event_type" enums:"job,document"`
-	RecordedAt time.Time        `json:"recorded_at" swaggertype:"primitive,string"`
-	Job        *JobMessage      `json:"job,omitempty"`      // Job contains jobs specific details. ensure event type is job
-	Document   *DocumentMessage `json:"document,omitempty"` // Document contains recently received document.
-	// Ensure event type is document
+	EventType  EventType `json:"event_type" enums:"job,document"`
+	RecordedAt time.Time `json:"recorded_at" swaggertype:"primitive,string"`
+
+	// Job contains jobs specific details. Ensure event type is job
+	Job *JobMessage `json:"job,omitempty"`
+
+	// Document contains recently received document. Ensure event type is document
+	Document *DocumentMessage `json:"document,omitempty"`
 }
 
 // Sender defines methods that can handle a notification.

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -5,6 +5,7 @@ package notification
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -12,14 +13,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/centrifuge/centrifuge-protobufs/documenttypes"
 	"github.com/centrifuge/go-centrifuge/bootstrap"
 	"github.com/centrifuge/go-centrifuge/bootstrap/bootstrappers/testlogging"
 	"github.com/centrifuge/go-centrifuge/config"
 	"github.com/centrifuge/go-centrifuge/contextutil"
-	"github.com/centrifuge/go-centrifuge/identity"
 	"github.com/centrifuge/go-centrifuge/utils"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,27 +36,12 @@ func TestMain(m *testing.M) {
 	os.Exit(result)
 }
 
-func TestWebhookSender_Send(t *testing.T) {
-	docID := utils.RandomSlice(32)
-	accountID := utils.RandomSlice(identity.DIDLength)
-	senderID := utils.RandomSlice(identity.DIDLength)
-	statusMsg := "failure"
-	message := "some random error"
+func sendAndVerify(t *testing.T, message Message) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/webhook", func(writer http.ResponseWriter, request *http.Request) {
-		var resp struct {
-			EventType    uint32    `json:"event_type,omitempty"`
-			AccountId    string    `json:"account_id,omitempty"`
-			FromId       string    `json:"from_id,omitempty"`
-			ToId         string    `json:"to_id,omitempty"`
-			Recorded     time.Time `json:"recorded,omitempty"`
-			DocumentType string    `json:"document_type,omitempty"`
-			DocumentId   string    `json:"document_id,omitempty"`
-			Status       string    `json:"status,omitempty"`
-			Message      string    `json:"message,omitempty"`
-		}
+		var resp Message
 		defer request.Body.Close()
 		data, err := ioutil.ReadAll(request.Body)
 		assert.NoError(t, err)
@@ -66,39 +49,61 @@ func TestWebhookSender_Send(t *testing.T) {
 		err = json.Unmarshal(data, &resp)
 		assert.NoError(t, err)
 		writer.Write([]byte("success"))
-		assert.Equal(t, hexutil.Encode(docID), resp.DocumentId)
-		assert.Equal(t, hexutil.Encode(accountID), resp.AccountId)
-		assert.Equal(t, hexutil.Encode(senderID), resp.FromId)
-		assert.Equal(t, statusMsg, resp.Status)
-		assert.Equal(t, message, resp.Message)
+		assert.Equal(t, message.EventType, resp.EventType)
+		if message.EventType == EventTypeJob {
+			assert.Equal(t, *message.Job, *resp.Job)
+			assert.Nil(t, resp.Document)
+		} else {
+			assert.Equal(t, *message.Document, *resp.Document)
+			assert.Nil(t, resp.Job)
+		}
 		wg.Done()
 	})
 
-	server := &http.Server{Addr: ":8090", Handler: mux}
+	addr, _, err := utils.GetFreeAddrPort()
+	assert.NoError(t, err)
+	server := &http.Server{Addr: addr, Handler: mux}
 	go server.ListenAndServe()
 	defer server.Close()
 
 	wb := NewWebhookSender()
-	notif := Message{
-		DocumentID:   hexutil.Encode(docID),
-		DocumentType: documenttypes.InvoiceDataTypeUrl,
-		AccountID:    hexutil.Encode(accountID),
-		FromID:       hexutil.Encode(senderID),
-		ToID:         hexutil.Encode(accountID),
-		EventType:    ReceivedPayload,
-		Recorded:     time.Now().UTC(),
-		Status:       statusMsg,
-		Message:      message,
-	}
-
-	url := "http://localhost:8090/webhook"
+	url := fmt.Sprintf("http://%s/webhook", addr)
 	cfg.Set("notifications.endpoint", url)
 	acc := new(config.MockAccount)
 	acc.On("GetReceiveEventNotificationEndpoint").Return(url).Once()
 	ctx, err := contextutil.New(context.Background(), acc)
 	assert.NoError(t, err)
-	status, err := wb.Send(ctx, notif)
+
+	err = wb.Send(ctx, message)
 	assert.NoError(t, err)
-	assert.Equal(t, status, Success)
 	wg.Wait()
+}
+
+func TestWebhookSender_JobUpdate(t *testing.T) {
+	message := Message{
+		EventType:  EventTypeJob,
+		RecordedAt: time.Now().UTC(),
+		Job: &JobMessage{
+			ID:         utils.RandomSlice(32),
+			Owner:      utils.RandomSlice(20),
+			Desc:       "Sample Job",
+			ValidUntil: time.Now().Add(time.Hour).UTC(),
+			FinishedAt: time.Now().UTC(),
+		},
+	}
+	sendAndVerify(t, message)
+}
+
+func TestWebhookSender_DocumentUpdate(t *testing.T) {
+	message := Message{
+		EventType:  EventTypeDocument,
+		RecordedAt: time.Now().UTC(),
+		Document: &DocumentMessage{
+			ID:        utils.RandomSlice(32),
+			VersionID: utils.RandomSlice(32),
+			From:      utils.RandomSlice(20),
+			To:        utils.RandomSlice(20),
+		},
+	}
+	sendAndVerify(t, message)
 }

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -43,6 +43,7 @@ func sendAndVerify(t *testing.T, message Message) {
 	mux.HandleFunc("/webhook", func(writer http.ResponseWriter, request *http.Request) {
 		var resp Message
 		defer request.Body.Close()
+		defer wg.Done()
 		data, err := ioutil.ReadAll(request.Body)
 		assert.NoError(t, err)
 
@@ -57,7 +58,6 @@ func sendAndVerify(t *testing.T, message Message) {
 			assert.Equal(t, *message.Document, *resp.Document)
 			assert.Nil(t, resp.Job)
 		}
-		wg.Done()
 	})
 
 	addr, _, err := utils.GetFreeAddrPort()

--- a/testworld/config.go
+++ b/testworld/config.go
@@ -91,7 +91,8 @@ func loadConfig(network string) (nc networkConfig, err error) {
 		return nc, nil
 	}
 
-	return nc, nil
+	// ensure sleepy config is deleted as it will be created later
+	return nc, os.RemoveAll(fmt.Sprintf("hostConfigs/%s/Sleepy", nc.Network))
 }
 
 func updateConfig(dir string, values map[string]interface{}) (err error) {

--- a/testworld/config_test.go
+++ b/testworld/config_test.go
@@ -35,7 +35,7 @@ func TestConfig_Happy(t *testing.T) {
 	}
 
 	// generate a tenant within Charlie
-	did, err := generateAccount(charlie.httpExpect, charlie.id.String(), http.StatusCreated, cacc)
+	did, err := generateAccount(doctorFord.maeve, charlie.httpExpect, charlie.id.String(), http.StatusCreated, cacc)
 	assert.NoError(t, err)
 	assert.False(t, did.Equal(charlie.id))
 }

--- a/testworld/core_api_docs_test.go
+++ b/testworld/core_api_docs_test.go
@@ -18,7 +18,8 @@ func TestCoreAPI_DocumentGenericCreateAndUpdate(t *testing.T) {
 	charlie := doctorFord.getHostTestSuite(t, "Charlie")
 
 	// Alice shares document with Bob first
-	docID := createAndCommitDocument(t, alice.httpExpect, alice.id.String(), genericCoreAPICreate([]string{bob.id.String()}))
+	docID := createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(),
+		genericCoreAPICreate([]string{bob.id.String()}))
 	params := map[string]interface{}{}
 	getDocumentAndVerify(t, alice.httpExpect, alice.id.String(), docID, params, createAttributes())
 	getDocumentAndVerify(t, bob.httpExpect, bob.id.String(), docID, params, createAttributes())
@@ -27,7 +28,7 @@ func TestCoreAPI_DocumentGenericCreateAndUpdate(t *testing.T) {
 	// Bob updates purchase order and shares with Charlie as well
 	payload := genericCoreAPIUpdate([]string{alice.id.String(), charlie.id.String()})
 	payload["document_id"] = docID
-	docID = createAndCommitDocument(t, bob.httpExpect, bob.id.String(), payload)
+	docID = createAndCommitDocument(t, doctorFord.maeve, bob.httpExpect, bob.id.String(), payload)
 	getDocumentAndVerify(t, alice.httpExpect, alice.id.String(), docID, params, allAttributes())
 	getDocumentAndVerify(t, bob.httpExpect, bob.id.String(), docID, params, allAttributes())
 	getDocumentAndVerify(t, charlie.httpExpect, charlie.id.String(), docID, params, allAttributes())
@@ -40,7 +41,7 @@ func TestCoreAPI_DocumentEntityCreateAndUpdate(t *testing.T) {
 	charlie := doctorFord.getHostTestSuite(t, "Charlie")
 
 	// Alice shares document with Bob first
-	docID := createAndCommitDocument(t, alice.httpExpect, alice.id.String(), entityCoreAPICreate(alice.id.String(), []string{bob.id.String(), charlie.id.String()}))
+	docID := createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(), entityCoreAPICreate(alice.id.String(), []string{bob.id.String(), charlie.id.String()}))
 	params := map[string]interface{}{
 		"identity":   alice.id.String(),
 		"legal_name": "test company",

--- a/testworld/document_consensus_test.go
+++ b/testworld/document_consensus_test.go
@@ -52,7 +52,7 @@ func addExternalCollaboratorWithinHost(t *testing.T) {
 	c := accounts[2]
 
 	// a shares document with b first
-	docID := createAndCommitDocument(t, bob.httpExpect, a, genericCoreAPICreate([]string{b}))
+	docID := createAndCommitDocument(t, doctorFord.maeve, bob.httpExpect, a, genericCoreAPICreate([]string{b}))
 	getDocumentAndVerify(t, bob.httpExpect, a, docID, nil, createAttributes())
 	getDocumentAndVerify(t, bob.httpExpect, b, docID, nil, createAttributes())
 
@@ -66,7 +66,7 @@ func addExternalCollaboratorWithinHost(t *testing.T) {
 	// b updates invoice and shares with c as well
 	payload := genericCoreAPIUpdate([]string{a, c})
 	payload["document_id"] = docID
-	docID = createAndCommitDocument(t, bob.httpExpect, b, payload)
+	docID = createAndCommitDocument(t, doctorFord.maeve, bob.httpExpect, b, payload)
 	getDocumentAndVerify(t, bob.httpExpect, a, docID, nil, allAttributes())
 	getDocumentAndVerify(t, bob.httpExpect, b, docID, nil, allAttributes())
 	getDocumentAndVerify(t, bob.httpExpect, c, docID, nil, allAttributes())
@@ -90,7 +90,7 @@ func addExternalCollaboratorMultiHostMultiAccount(t *testing.T) {
 	f := accounts2[2]
 
 	// Alice shares document with Bobs accounts a and b
-	docID := createAndCommitDocument(t, alice.httpExpect, alice.id.String(), genericCoreAPICreate([]string{a, b}))
+	docID := createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(), genericCoreAPICreate([]string{a, b}))
 	getDocumentAndVerify(t, alice.httpExpect, alice.id.String(), docID, nil, createAttributes())
 	getDocumentAndVerify(t, bob.httpExpect, a, docID, nil, createAttributes())
 	getDocumentAndVerify(t, bob.httpExpect, b, docID, nil, createAttributes())
@@ -104,7 +104,7 @@ func addExternalCollaboratorMultiHostMultiAccount(t *testing.T) {
 	// Bob updates invoice and shares with bobs account c as well using account a and to accounts d and e of Charlie
 	payload := genericCoreAPIUpdate([]string{alice.id.String(), b, c, d, e})
 	payload["document_id"] = docID
-	docID = createAndCommitDocument(t, bob.httpExpect, a, payload)
+	docID = createAndCommitDocument(t, doctorFord.maeve, bob.httpExpect, a, payload)
 	getDocumentAndVerify(t, alice.httpExpect, alice.id.String(), docID, nil, allAttributes())
 	// bobs accounts all have the document now
 	getDocumentAndVerify(t, bob.httpExpect, a, docID, nil, allAttributes())
@@ -121,7 +121,7 @@ func addExternalCollaborator(t *testing.T) {
 	charlie := doctorFord.getHostTestSuite(t, "Charlie")
 
 	// Alice shares document with Bob first
-	docID := createAndCommitDocument(t, alice.httpExpect, alice.id.String(), genericCoreAPICreate([]string{bob.id.String()}))
+	docID := createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(), genericCoreAPICreate([]string{bob.id.String()}))
 	getDocumentAndVerify(t, alice.httpExpect, alice.id.String(), docID, nil, createAttributes())
 	getDocumentAndVerify(t, bob.httpExpect, bob.id.String(), docID, nil, createAttributes())
 	nonExistingDocumentCheck(charlie.httpExpect, charlie.id.String(), docID)
@@ -129,7 +129,7 @@ func addExternalCollaborator(t *testing.T) {
 	// Bob updates invoice and shares with Charlie as well
 	payload := genericCoreAPIUpdate([]string{alice.id.String(), charlie.id.String()})
 	payload["document_id"] = docID
-	docID = createAndCommitDocument(t, bob.httpExpect, bob.id.String(), payload)
+	docID = createAndCommitDocument(t, doctorFord.maeve, bob.httpExpect, bob.id.String(), payload)
 	getDocumentAndVerify(t, alice.httpExpect, alice.id.String(), docID, nil, allAttributes())
 	getDocumentAndVerify(t, bob.httpExpect, bob.id.String(), docID, nil, allAttributes())
 	getDocumentAndVerify(t, charlie.httpExpect, charlie.id.String(), docID, nil, allAttributes())
@@ -144,7 +144,7 @@ func collaboratorTimeOut(t *testing.T) {
 	bob := doctorFord.getHostTestSuite(t, "Bob")
 
 	// Kenny shares a document with Bob
-	docID := createAndCommitDocument(t, kenny.httpExpect, kenny.id.String(), genericCoreAPICreate([]string{bob.id.String()}))
+	docID := createAndCommitDocument(t, doctorFord.maeve, kenny.httpExpect, kenny.id.String(), genericCoreAPICreate([]string{bob.id.String()}))
 	getDocumentAndVerify(t, kenny.httpExpect, kenny.id.String(), docID, nil, createAttributes())
 	getDocumentAndVerify(t, bob.httpExpect, bob.id.String(), docID, nil, createAttributes())
 
@@ -155,7 +155,7 @@ func collaboratorTimeOut(t *testing.T) {
 	// Bob will anchor the document without Kennys signature
 	payload := genericCoreAPIUpdate([]string{kenny.id.String()})
 	payload["document_id"] = docID
-	docID = createAndCommitDocument(t, bob.httpExpect, bob.id.String(), payload)
+	docID = createAndCommitDocument(t, doctorFord.maeve, bob.httpExpect, bob.id.String(), payload)
 	getDocumentAndVerify(t, bob.httpExpect, bob.id.String(), docID, nil, allAttributes())
 
 	// bring Kenny back to life
@@ -188,7 +188,7 @@ func TestDocument_latestDocumentVersion(t *testing.T) {
 	kenny := doctorFord.getHostTestSuite(t, "Kenny")
 
 	// alice creates a document with bob and kenny
-	docID := createAndCommitDocument(t, alice.httpExpect, alice.id.String(),
+	docID := createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(),
 		genericCoreAPICreate([]string{alice.id.String(), bob.id.String(), kenny.id.String()}))
 	getDocumentAndVerify(t, alice.httpExpect, alice.id.String(), docID, nil, createAttributes())
 	getDocumentAndVerify(t, bob.httpExpect, bob.id.String(), docID, nil, createAttributes())
@@ -199,7 +199,7 @@ func TestDocument_latestDocumentVersion(t *testing.T) {
 	kenny.host.kill()
 	payload := genericCoreAPIUpdate([]string{charlie.id.String()})
 	payload["document_id"] = docID
-	docID = createAndCommitDocument(t, bob.httpExpect, bob.id.String(), payload)
+	docID = createAndCommitDocument(t, doctorFord.maeve, bob.httpExpect, bob.id.String(), payload)
 	getDocumentAndVerify(t, bob.httpExpect, bob.id.String(), docID, nil, allAttributes())
 	getDocumentAndVerify(t, alice.httpExpect, alice.id.String(), docID, nil, allAttributes())
 	getDocumentAndVerify(t, charlie.httpExpect, charlie.id.String(), docID, nil, allAttributes())
@@ -210,7 +210,7 @@ func TestDocument_latestDocumentVersion(t *testing.T) {
 	// alice updates document
 	payload = genericCoreAPIUpdate(nil)
 	payload["document_id"] = docID
-	docID = createAndCommitDocument(t, alice.httpExpect, alice.id.String(), payload)
+	docID = createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(), payload)
 
 	// everyone should have the latest version
 	getDocumentAndVerify(t, alice.httpExpect, alice.id.String(), docID, nil, allAttributes())

--- a/testworld/document_consensus_test.go
+++ b/testworld/document_consensus_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/centrifuge/go-centrifuge/notification"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -58,9 +57,9 @@ func addExternalCollaboratorWithinHost(t *testing.T) {
 	getDocumentAndVerify(t, bob.httpExpect, b, docID, nil, createAttributes())
 
 	// account b sends a webhook for received anchored doc
-	msg, err := doctorFord.maeve.getReceivedMsg(b, int(notification.ReceivedPayload), docID)
+	msg, err := doctorFord.maeve.getReceivedDocumentMsg(b, docID)
 	assert.NoError(t, err)
-	assert.Equal(t, strings.ToLower(a), strings.ToLower(msg.FromID))
+	assert.Equal(t, strings.ToLower(a), strings.ToLower(msg.Document.From.String()))
 	log.Debug("Host test success")
 	nonExistingDocumentCheck(bob.httpExpect, c, docID)
 
@@ -72,9 +71,9 @@ func addExternalCollaboratorWithinHost(t *testing.T) {
 	getDocumentAndVerify(t, bob.httpExpect, b, docID, nil, allAttributes())
 	getDocumentAndVerify(t, bob.httpExpect, c, docID, nil, allAttributes())
 	// account c sends a webhook for received anchored doc
-	msg, err = doctorFord.maeve.getReceivedMsg(c, int(notification.ReceivedPayload), docID)
+	msg, err = doctorFord.maeve.getReceivedDocumentMsg(c, docID)
 	assert.NoError(t, err)
-	assert.Equal(t, strings.ToLower(b), strings.ToLower(msg.FromID))
+	assert.Equal(t, strings.ToLower(b), strings.ToLower(msg.Document.From.String()))
 }
 
 func addExternalCollaboratorMultiHostMultiAccount(t *testing.T) {
@@ -97,9 +96,9 @@ func addExternalCollaboratorMultiHostMultiAccount(t *testing.T) {
 	getDocumentAndVerify(t, bob.httpExpect, b, docID, nil, createAttributes())
 
 	// bobs account b sends a webhook for received anchored doc
-	msg, err := doctorFord.maeve.getReceivedMsg(b, int(notification.ReceivedPayload), docID)
+	msg, err := doctorFord.maeve.getReceivedDocumentMsg(b, docID)
 	assert.NoError(t, err)
-	assert.Equal(t, strings.ToLower(alice.id.String()), strings.ToLower(msg.FromID))
+	assert.Equal(t, strings.ToLower(alice.id.String()), strings.ToLower(msg.Document.From.String()))
 	nonExistingDocumentCheck(bob.httpExpect, c, docID)
 
 	// Bob updates invoice and shares with bobs account c as well using account a and to accounts d and e of Charlie

--- a/testworld/entity_relationships_test.go
+++ b/testworld/entity_relationships_test.go
@@ -17,10 +17,10 @@ func TestHost_Entity_EntityRelationships(t *testing.T) {
 	charlie := doctorFord.getHostTestSuite(t, "Charlie")
 
 	// Alice anchors entity
-	docID := createAndCommitDocument(t, alice.httpExpect, alice.id.String(), defaultEntityPayload(alice.id.String(), []string{}))
+	docID := createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(), defaultEntityPayload(alice.id.String(), []string{}))
 
 	// Alice creates an EntityRelationship with Bob
-	erID := createAndCommitDocument(t, alice.httpExpect, alice.id.String(),
+	erID := createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(),
 		defaultRelationshipPayload(alice.id.String(), docID,
 			bob.id.String()))
 
@@ -34,7 +34,7 @@ func TestHost_Entity_EntityRelationships(t *testing.T) {
 	// Alice updates her entity
 	payload := updatedEntityPayload(alice.id.String(), []string{})
 	payload["document_id"] = docID
-	docID = createAndCommitDocument(t, alice.httpExpect, alice.id.String(), payload)
+	docID = createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(), payload)
 
 	// Bob accesses the Entity through the EntityRelationship with Alice, this should return him the latest/updated Entity data
 	response = getEntityWithRelation(bob.httpExpect, bob.id.String(), erID)
@@ -48,7 +48,7 @@ func TestHost_Entity_EntityRelationships(t *testing.T) {
 	relationship.Path("$.data.target_identity").String().Equal(bob.id.String())
 
 	// Alice creates an EntityRelationship with Charlie
-	cerID := createAndCommitDocument(t, alice.httpExpect, alice.id.String(),
+	cerID := createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(),
 		defaultRelationshipPayload(alice.id.String(), docID, charlie.id.String()))
 
 	// Charlie should now have access to the Entity Data
@@ -63,7 +63,7 @@ func TestHost_Entity_EntityRelationships(t *testing.T) {
 	// Alice revokes the EntityRelationship with Bob
 	payload = defaultRelationshipPayload(alice.id.String(), docID, bob.id.String())
 	payload["document_id"] = erID
-	erID = createAndCommitDocument(t, alice.httpExpect, alice.id.String(), payload)
+	erID = createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(), payload)
 
 	// Bob should no longer have access to the EntityRelationship
 	nonexistentEntityWithRelation(bob.httpExpect, bob.id.String(), erID)

--- a/testworld/entity_test.go
+++ b/testworld/entity_test.go
@@ -15,7 +15,7 @@ func TestHost_BasicEntity(t *testing.T) {
 	charlie := doctorFord.getHostTestSuite(t, "Charlie")
 
 	// Alice shares a document with Bob and Charlie
-	docID := createAndCommitDocument(t, alice.httpExpect, alice.id.String(), defaultEntityPayload(alice.id.String(),
+	docID := createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(), defaultEntityPayload(alice.id.String(),
 		[]string{bob.id.String(), charlie.id.String()}))
 
 	params := map[string]interface{}{
@@ -34,10 +34,10 @@ func TestHost_EntityShareGet(t *testing.T) {
 	bob := doctorFord.getHostTestSuite(t, "Bob")
 
 	// Alice anchors Entity
-	docID := createAndCommitDocument(t, alice.httpExpect, alice.id.String(), defaultEntityPayload(alice.id.String(), []string{}))
+	docID := createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(), defaultEntityPayload(alice.id.String(), []string{}))
 
 	// Alice creates an EntityRelationship with Bob
-	relID := createAndCommitDocument(t, alice.httpExpect, alice.id.String(),
+	relID := createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(),
 		defaultRelationshipPayload(alice.id.String(), docID, bob.id.String()))
 
 	response := getEntityWithRelation(bob.httpExpect, bob.id.String(), relID)

--- a/testworld/nft_test.go
+++ b/testworld/nft_test.go
@@ -29,7 +29,7 @@ func defaultNFTMint(t *testing.T) (string, nft.TokenID) {
 	docPayload := genericCoreAPICreate([]string{bob.id.String()})
 	attrs, pfs := getAttributeMapRequest(t, alice.id)
 	docPayload["attributes"] = attrs
-	docID := createAndCommitDocument(t, alice.httpExpect, alice.id.String(), docPayload)
+	docID := createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(), docPayload)
 	getDocumentAndVerify(t, alice.httpExpect, alice.id.String(), docID, nil, attrs)
 	getDocumentAndVerify(t, bob.httpExpect, bob.id.String(), docID, nil, attrs)
 
@@ -52,9 +52,8 @@ func defaultNFTMint(t *testing.T) (string, nft.TokenID) {
 	response, err = alice.host.mintNFT(alice.httpExpect, alice.id.String(), http.StatusAccepted, payload)
 	assert.NoError(t, err, "mintNFT should be successful")
 	jobID := getJobID(t, response)
-	ok, err := waitForJobComplete(alice.httpExpect, alice.id.String(), jobID)
+	err = waitForJobComplete(doctorFord.maeve, alice.httpExpect, alice.id.String(), jobID)
 	assert.NoError(t, err)
-	assert.True(t, ok)
 
 	docVal := getDocumentAndVerify(t, alice.httpExpect, alice.id.String(), docID, nil, attrs)
 	assert.True(t, len(docVal.Path("$.header.nfts[0].token_id").String().Raw()) > 0, "successful tokenId should have length 77")
@@ -97,9 +96,8 @@ func TestTransferNFT_successful(t *testing.T) {
 	response, err := alice.host.transferNFT(alice.httpExpect, alice.id.String(), http.StatusOK, transferPayload)
 	assert.NoError(t, err)
 	jobID := getJobID(t, response)
-	ok, err := waitForJobComplete(alice.httpExpect, alice.id.String(), jobID)
+	err = waitForJobComplete(doctorFord.maeve, alice.httpExpect, alice.id.String(), jobID)
 	assert.NoError(t, err)
-	assert.True(t, ok)
 
 	// nft owner should be bob
 	resp, err = alice.host.ownerOfNFT(alice.httpExpect, alice.id.String(), http.StatusOK, ownerOfPayload)

--- a/testworld/nft_test.go
+++ b/testworld/nft_test.go
@@ -26,7 +26,7 @@ func defaultNFTMint(t *testing.T) (string, nft.TokenID) {
 	assetAddress := common.HexToAddress(alice.host.dappAddresses["assetManager"])
 
 	// Alice shares document with Bob
-	docPayload := genericCoreAPICreate([]string{bob.id.String()})
+	docPayload := genericCoreAPICreate([]string{alice.id.String(), bob.id.String()})
 	attrs, pfs := getAttributeMapRequest(t, alice.id)
 	docPayload["attributes"] = attrs
 	docID := createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(), docPayload)

--- a/testworld/park.go
+++ b/testworld/park.go
@@ -185,7 +185,7 @@ func (r *hostManager) init() error {
 		}
 		fmt.Printf("DID for %s is %s \n", name, i)
 		if r.config.CreateHostConfigs {
-			_ = host.createAccounts(r.getHostTestSuite(&testing.T{}, host.name).httpExpect)
+			_ = host.createAccounts(r.maeve, r.getHostTestSuite(&testing.T{}, host.name).httpExpect)
 		}
 		_ = host.loadAccounts(r.getHostTestSuite(&testing.T{}, host.name).httpExpect)
 	}
@@ -425,7 +425,7 @@ func (h *host) ownerOfNFT(e *httpexpect.Expect, auth string, status int, params 
 	return ownerOfNFT(e, auth, status, params), nil
 }
 
-func (h *host) createAccounts(e *httpexpect.Expect) error {
+func (h *host) createAccounts(maeve *webhookReceiver, e *httpexpect.Expect) error {
 	if !h.multiAccount {
 		return nil
 	}
@@ -440,7 +440,7 @@ func (h *host) createAccounts(e *httpexpect.Expect) error {
 
 	for i := 0; i < 3; i++ {
 		log.Infof("creating account %d for host %s", i, h.name)
-		did, err := generateAccount(e, h.identity.String(), http.StatusCreated, cacc)
+		did, err := generateAccount(maeve, e, h.identity.String(), http.StatusCreated, cacc)
 		if err != nil {
 			return err
 		}

--- a/testworld/park_test.go
+++ b/testworld/park_test.go
@@ -20,7 +20,7 @@ func TestHost_BasicDocumentShare(t *testing.T) {
 	charlie := doctorFord.getHostTestSuite(t, "Charlie")
 
 	// alice shares a document with bob and charlie
-	docID := createAndCommitDocument(t, alice.httpExpect, alice.id.String(),
+	docID := createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(),
 		genericCoreAPICreate([]string{bob.id.String(), charlie.id.String()}))
 
 	getDocumentAndVerify(t, alice.httpExpect, alice.id.String(), docID, nil, createAttributes())
@@ -48,7 +48,7 @@ func TestHost_RestartWithAccounts(t *testing.T) {
 	sleepyTS := doctorFord.getHostTestSuite(t, tempHostName)
 
 	// Create accounts for new host
-	err = sleepyHost.createAccounts(sleepyTS.httpExpect)
+	err = sleepyHost.createAccounts(doctorFord.maeve, sleepyTS.httpExpect)
 	assert.NoError(t, err)
 	err = sleepyHost.loadAccounts(sleepyTS.httpExpect)
 	assert.NoError(t, err)

--- a/testworld/park_test.go
+++ b/testworld/park_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/centrifuge/go-centrifuge/notification"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,9 +28,9 @@ func TestHost_BasicDocumentShare(t *testing.T) {
 	getDocumentAndVerify(t, charlie.httpExpect, charlie.id.String(), docID, nil, createAttributes())
 
 	// bobs node sends a webhook for received anchored doc
-	msg, err := doctorFord.maeve.getReceivedMsg(bob.id.String(), int(notification.ReceivedPayload), docID)
+	msg, err := doctorFord.maeve.getReceivedDocumentMsg(bob.id.String(), docID)
 	assert.NoError(t, err)
-	assert.Equal(t, strings.ToLower(alice.id.String()), strings.ToLower(msg.FromID))
+	assert.Equal(t, strings.ToLower(alice.id.String()), strings.ToLower(msg.Document.From.String()))
 }
 
 func TestHost_RestartWithAccounts(t *testing.T) {

--- a/testworld/proof_test.go
+++ b/testworld/proof_test.go
@@ -19,7 +19,7 @@ func proofWithMultipleFieldsSuccessful(t *testing.T, documentType string) {
 	bob := doctorFord.getHostTestSuite(t, "Bob")
 
 	// Alice shares a document with Bob
-	docID := createAndCommitDocument(t, alice.httpExpect, alice.id.String(), genericCoreAPICreate([]string{bob.id.String()}))
+	docID := createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(), genericCoreAPICreate([]string{bob.id.String()}))
 	proofPayload := defaultProofPayload(documentType)
 	proofFromAlice := getProof(alice.httpExpect, alice.id.String(), http.StatusOK, docID, proofPayload)
 	proofFromBob := getProof(bob.httpExpect, bob.id.String(), http.StatusOK, docID, proofPayload)

--- a/testworld/rules_test.go
+++ b/testworld/rules_test.go
@@ -64,9 +64,8 @@ func setupTransitionRuleForCharlie(t *testing.T) (string, string) {
 	// commit document
 	res = commitDocument(alice.httpExpect, alice.id.String(), "documents", http.StatusAccepted, docID)
 	jobID := getJobID(t, res)
-	ok, err := waitForJobComplete(alice.httpExpect, alice.id.String(), jobID)
+	err := waitForJobComplete(doctorFord.maeve, alice.httpExpect, alice.id.String(), jobID)
 	assert.NoError(t, err)
-	assert.True(t, ok)
 	getDocumentAndVerify(t, alice.httpExpect, alice.id.String(), docID, nil, createAttributes())
 	// pending document should fail
 	getV2DocumentWithStatus(alice.httpExpect, alice.id.String(), docID, "pending", http.StatusNotFound)
@@ -93,9 +92,8 @@ func TestTransitionRules(t *testing.T) {
 	res := commitDocument(charlie.httpExpect, charlie.id.String(), "documents", http.StatusAccepted, docID)
 	versionID := getDocumentCurrentVersion(t, res)
 	jobID := getJobID(t, res)
-	ok, err := waitForJobComplete(charlie.httpExpect, charlie.id.String(), jobID)
+	err := waitForJobComplete(doctorFord.maeve, charlie.httpExpect, charlie.id.String(), jobID)
 	assert.NoError(t, err)
-	assert.True(t, ok)
 	// alice and bob would have not accepted the document update.
 	nonExistingGenericDocumentVersionCheck(alice.httpExpect, alice.id.String(), docID, versionID)
 	nonExistingGenericDocumentVersionCheck(bob.httpExpect, bob.id.String(), docID, versionID)
@@ -110,7 +108,7 @@ func TestTransitionRules(t *testing.T) {
 		},
 	}
 	p["document_id"] = docID
-	docID = createAndCommitDocument(t, charlie.httpExpect, charlie.id.String(), p)
+	docID = createAndCommitDocument(t, doctorFord.maeve, charlie.httpExpect, charlie.id.String(), p)
 
 	// alice deletes the rule
 	p = genericCoreAPICreate(nil)
@@ -130,9 +128,8 @@ func TestTransitionRules(t *testing.T) {
 	// commit the document
 	res = commitDocument(alice.httpExpect, alice.id.String(), "documents", http.StatusAccepted, docID)
 	jobID = getJobID(t, res)
-	ok, err = waitForJobComplete(alice.httpExpect, alice.id.String(), jobID)
+	err = waitForJobComplete(doctorFord.maeve, alice.httpExpect, alice.id.String(), jobID)
 	assert.NoError(t, err)
-	assert.True(t, ok)
 
 	// charlie should not have latest document
 	nonExistingGenericDocumentVersionCheck(charlie.httpExpect, charlie.id.String(), docID, versionID)

--- a/testworld/signature_test.go
+++ b/testworld/signature_test.go
@@ -207,7 +207,7 @@ func TestHost_RevokedSigningKey(t *testing.T) {
 	assert.Equal(t, 0, len(signatures))
 
 	// Even though there was a signature validation error, as of now, we keep anchoring document
-	createAndCommitDocument(t, bob.httpExpect, bob.id.String(), genericCoreAPICreate([]string{eve.id.String()}))
+	createAndCommitDocument(t, doctorFord.maeve, bob.httpExpect, bob.id.String(), genericCoreAPICreate([]string{eve.id.String()}))
 }
 
 // Helper Methods

--- a/testworld/v2_documents_test.go
+++ b/testworld/v2_documents_test.go
@@ -110,9 +110,8 @@ func createNewDocument(
 	// Commits document and shares with Bob
 	res = commitDocument(alice.httpExpect, alice.id.String(), "documents", http.StatusAccepted, docID)
 	jobID := getJobID(t, res)
-	ok, err := waitForJobComplete(alice.httpExpect, alice.id.String(), jobID)
+	err := waitForJobComplete(doctorFord.maeve, alice.httpExpect, alice.id.String(), jobID)
 	assert.NoError(t, err)
-	assert.True(t, ok)
 	getDocumentAndVerify(t, alice.httpExpect, alice.id.String(), docID, nil, updateAttributes())
 
 	// pending document should fail
@@ -136,7 +135,7 @@ func createNextDocument(t *testing.T, createPayload func([]string) map[string]in
 	bob := doctorFord.getHostTestSuite(t, "Bob")
 
 	// Alice shares document with Bob
-	docID := createAndCommitDocument(t, alice.httpExpect, alice.id.String(), createPayload([]string{bob.id.String()}))
+	docID := createAndCommitDocument(t, doctorFord.maeve, alice.httpExpect, alice.id.String(), createPayload([]string{bob.id.String()}))
 	res := getDocumentAndVerify(t, bob.httpExpect, bob.id.String(), docID, nil, createAttributes()).Object()
 	versionID := getDocumentCurrentVersion(t, res)
 	assert.Equal(t, docID, versionID, "failed to create a fresh document")
@@ -164,9 +163,8 @@ func createNextDocument(t *testing.T, createPayload func([]string) map[string]in
 	// Commits document and shares with alice
 	res = commitDocument(bob.httpExpect, bob.id.String(), "documents", http.StatusAccepted, docID)
 	jobID := getJobID(t, res)
-	ok, err := waitForJobComplete(bob.httpExpect, bob.id.String(), jobID)
+	err := waitForJobComplete(doctorFord.maeve, bob.httpExpect, bob.id.String(), jobID)
 	assert.NoError(t, err)
-	assert.True(t, ok)
 
 	// bob shouldn't have any pending documents but has a committed one
 	getV2DocumentWithStatus(bob.httpExpect, bob.id.String(), docID, "pending", http.StatusNotFound)
@@ -195,9 +193,8 @@ func cloneNewDocument(
 	// Commits template
 	res = commitDocument(alice.httpExpect, alice.id.String(), "documents", http.StatusAccepted, docID)
 	jobID := getJobID(t, res)
-	ok, err := waitForJobComplete(alice.httpExpect, alice.id.String(), jobID)
+	err := waitForJobComplete(doctorFord.maeve, alice.httpExpect, alice.id.String(), jobID)
 	assert.NoError(t, err)
-	assert.True(t, ok)
 	getDocumentAndVerify(t, alice.httpExpect, alice.id.String(), docID, nil, createAttributes())
 
 	// Bob should have the template
@@ -214,9 +211,8 @@ func cloneNewDocument(
 	assert.NotEmpty(t, docID1)
 	res = commitDocument(bob.httpExpect, bob.id.String(), "documents", http.StatusAccepted, docID1)
 	jobID = getJobID(t, res)
-	ok, err = waitForJobComplete(bob.httpExpect, bob.id.String(), jobID)
+	err = waitForJobComplete(doctorFord.maeve, bob.httpExpect, bob.id.String(), jobID)
 	assert.NoError(t, err)
-	assert.True(t, ok)
 
 	getClonedDocumentAndCheck(t, bob.httpExpect, bob.id.String(), docID, docID1, nil, createAttributes())
 }
@@ -278,9 +274,8 @@ func TestDocument_ComputeFields(t *testing.T) {
 	// commits the document
 	res = commitDocument(alice.httpExpect, alice.id.String(), "documents", http.StatusAccepted, docID)
 	jobID := getJobID(t, res)
-	ok, err := waitForJobComplete(alice.httpExpect, alice.id.String(), jobID)
+	err = waitForJobComplete(doctorFord.maeve, alice.httpExpect, alice.id.String(), jobID)
 	assert.NoError(t, err)
-	assert.True(t, ok)
 	var result [32]byte
 	getDocumentAndVerify(t, alice.httpExpect, alice.id.String(), docID, nil, withComputeFieldResultAttribute(result[:]))
 	getDocumentAndVerify(t, bob.httpExpect, bob.id.String(), docID, nil, withComputeFieldResultAttribute(result[:]))
@@ -303,7 +298,7 @@ func TestDocument_ComputeFields(t *testing.T) {
 	}
 	p["attributes"] = attrs
 	p["document_id"] = docID
-	createAndCommitDocument(t, bob.httpExpect, bob.id.String(), p)
+	createAndCommitDocument(t, doctorFord.maeve, bob.httpExpect, bob.id.String(), p)
 
 	// result = encoded(risk(1)) + encoded((1000+2000+3000)/3 = 1000)
 	result = [32]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x7, 0xd0}
@@ -329,7 +324,6 @@ func TestPushToOracle(t *testing.T) {
 	}
 	obj := pushToOracle(alice.httpExpect, alice.id.String(), docID, payload, http.StatusAccepted)
 	jobID := obj.Raw()["job_id"].(string)
-	ok, err := waitForJobComplete(alice.httpExpect, alice.id.String(), jobID)
+	err = waitForJobComplete(doctorFord.maeve, alice.httpExpect, alice.id.String(), jobID)
 	assert.NoError(t, err)
-	assert.True(t, ok)
 }


### PR DESCRIPTION
Closes #1057 

This PR makes the following changes:
- Webhook message contains different payloads depending on the event type i.e.. job document etc...
- Testworld will rely on webhook for job completions instead of polling the job status
	- With job polling for a given test https://travis-ci.com/github/centrifuge/go-centrifuge/jobs/484019171#L2726
	- Without job polling for the same test https://travis-ci.com/github/centrifuge/go-centrifuge/jobs/484274096#L2588
	- We poll the job only when we receive the job complete webhook