### PR TITLE
Validate urls

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -666,7 +666,7 @@ func CreateConfigFile(args map[string]interface{}) (*viper.Viper, error) {
 	if p2pConnectTimeout != "" {
 		v.Set("p2p.connectTimeout", p2pConnectTimeout)
 	}
-	v.Set("ethereum.nodeURL", parseURL(ethNodeURL))
+	v.Set("ethereum.nodeURL", validateURL(ethNodeURL))
 	v.Set("ethereum.accounts.main.key", "")
 	v.Set("ethereum.accounts.main.password", "")
 	v.Set("centChain.nodeURL", centChainURL)
@@ -732,7 +732,7 @@ func getEthereumAccountAddressFromKey(key string) (string, error) {
 	return ethAddr.Address, nil
 }
 
-func parseURL(u string) string {
+func validateURL(u string) string {
 	parsedURL, err := url.Parse(u)
 	if err != nil {
 		log.Fatalf("error: %v", err)

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -604,7 +604,8 @@ func (c *configuration) initializeViper() {
 
 func (c *configuration) validateURLs(keys []string) error {
 	for _, key := range keys {
-		value, err := validateURL(c.v.Get(key).(string))
+		value, _ := c.v.Get(key).(string)
+		value, err := validateURL(value)
 		if err != nil {
 			return err
 		}
@@ -624,7 +625,10 @@ func CreateConfigFile(args map[string]interface{}) (*viper.Viper, error) {
 	accountKeyPath := args["accountKeyPath"].(string)
 	accountPassword := args["accountPassword"].(string)
 	network := args["network"].(string)
-	ethNodeURL := args["ethNodeURL"].(string)
+	ethNodeURL, err := validateURL(args["ethNodeURL"].(string))
+	if err != nil {
+		return nil, err
+	}
 	bootstraps := args["bootstraps"].([]string)
 	apiPort := args["apiPort"].(int64)
 	p2pPort := args["p2pPort"].(int64)
@@ -633,6 +637,10 @@ func CreateConfigFile(args map[string]interface{}) (*viper.Viper, error) {
 	apiHost := args["apiHost"].(string)
 	webhookURL, _ := args["webhookURL"].(string)
 	centChainURL, _ := args["centChainURL"].(string)
+	centChainURL, err = validateURL(centChainURL)
+	if err != nil {
+		return nil, err
+	}
 	centChainID, _ := args["centChainID"].(string)
 	centChainSecret, _ := args["centChainSecret"].(string)
 	centChainAddr, _ := args["centChainAddr"].(string)

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
+	"net/url"
 	"os"
 	"reflect"
 	"strings"
@@ -42,6 +43,8 @@ type ContractName string
 type ContractOp string
 
 const (
+	defaultURLPrefix = "https"
+
 	// AnchorRepo is the contract name for AnchorRepo
 	AnchorRepo ContractName = "anchorRepository"
 
@@ -663,7 +666,7 @@ func CreateConfigFile(args map[string]interface{}) (*viper.Viper, error) {
 	if p2pConnectTimeout != "" {
 		v.Set("p2p.connectTimeout", p2pConnectTimeout)
 	}
-	v.Set("ethereum.nodeURL", ethNodeURL)
+	v.Set("ethereum.nodeURL", parseURL(ethNodeURL))
 	v.Set("ethereum.accounts.main.key", "")
 	v.Set("ethereum.accounts.main.password", "")
 	v.Set("centChain.nodeURL", centChainURL)
@@ -727,4 +730,17 @@ func getEthereumAccountAddressFromKey(key string) (string, error) {
 		return "", err
 	}
 	return ethAddr.Address, nil
+}
+
+func parseURL(u string) string {
+	parsedURL, err := url.Parse(u)
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+
+	if parsedURL.Scheme == "" {
+		parsedURL.Scheme = defaultURLPrefix
+	}
+
+	return parsedURL.String()
 }

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -33,6 +33,12 @@ import (
 
 var log = logging.Logger("config")
 
+var allowedURLScheme = map[string]struct{}{
+	"http":  {},
+	"https": {},
+	"ws":    {},
+}
+
 // AccountHeaderKey is used as key for the account identity in the context.ContextWithValue.
 var AccountHeaderKey struct{}
 
@@ -740,7 +746,9 @@ func validateURL(u string) string {
 
 	if parsedURL.Scheme == "" {
 		parsedURL.Scheme = defaultURLScheme
-	} else if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+	}
+
+	if _, ok := allowedURLScheme[parsedURL.Scheme]; !ok {
 		log.Fatalf("error: url scheme %s is not allowed", parsedURL.Scheme)
 	}
 

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -595,6 +595,22 @@ func (c *configuration) initializeViper() {
 	c.v.AutomaticEnv()
 	c.v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	c.v.SetEnvPrefix("CENT")
+
+	err = c.validateURLs([]string{"ethNodeURL", "centChainURL"})
+	if err != nil {
+		log.Panicf("error: %v", err)
+	}
+}
+
+func (c *configuration) validateURLs(keys []string) error {
+	for _, key := range keys {
+		value, err := validateURL(c.v.Get(key).(string))
+		if err != nil {
+			return err
+		}
+		c.v.Set(key, value)
+	}
+	return nil
 }
 
 // SmartContractAddresses encapsulates the smart contract addresses
@@ -608,10 +624,7 @@ func CreateConfigFile(args map[string]interface{}) (*viper.Viper, error) {
 	accountKeyPath := args["accountKeyPath"].(string)
 	accountPassword := args["accountPassword"].(string)
 	network := args["network"].(string)
-	ethNodeURL, err := validateURL(args["ethNodeURL"].(string))
-	if err != nil {
-		return nil, err
-	}
+	ethNodeURL := args["ethNodeURL"].(string)
 	bootstraps := args["bootstraps"].([]string)
 	apiPort := args["apiPort"].(int64)
 	p2pPort := args["p2pPort"].(int64)
@@ -619,10 +632,7 @@ func CreateConfigFile(args map[string]interface{}) (*viper.Viper, error) {
 	preCommitEnabled := args["preCommitEnabled"].(bool)
 	apiHost := args["apiHost"].(string)
 	webhookURL, _ := args["webhookURL"].(string)
-	centChainURL, err := validateURL(args["centChainURL"].(string))
-	if err != nil {
-		return nil, err
-	}
+	centChainURL, _ := args["centChainURL"].(string)
 	centChainID, _ := args["centChainID"].(string)
 	centChainSecret, _ := args["centChainSecret"].(string)
 	centChainAddr, _ := args["centChainAddr"].(string)
@@ -756,7 +766,7 @@ func validateURL(u string) (string, error) {
 	}
 
 	if _, ok := allowedURLScheme[parsedURL.Scheme]; !ok {
-		return "", errors.New("error: url scheme %s is not allowed", parsedURL.Scheme)
+		return "", errors.New("url scheme %s is not allowed", parsedURL.Scheme)
 	}
 
 	return parsedURL.String(), nil

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -43,7 +43,7 @@ type ContractName string
 type ContractOp string
 
 const (
-	defaultURLPrefix = "https"
+	defaultURLScheme = "https"
 
 	// AnchorRepo is the contract name for AnchorRepo
 	AnchorRepo ContractName = "anchorRepository"
@@ -739,7 +739,7 @@ func validateURL(u string) string {
 	}
 
 	if parsedURL.Scheme == "" {
-		parsedURL.Scheme = defaultURLPrefix
+		parsedURL.Scheme = defaultURLScheme
 	} else if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
 		log.Fatalf("error: url scheme %s is not allowed", parsedURL.Scheme)
 	}

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -740,6 +740,8 @@ func validateURL(u string) string {
 
 	if parsedURL.Scheme == "" {
 		parsedURL.Scheme = defaultURLPrefix
+	} else if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		log.Fatalf("error: url scheme %s is not allowed", parsedURL.Scheme)
 	}
 
 	return parsedURL.String()

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -59,3 +59,43 @@ func TestConfiguration_CreateConfigFile(t *testing.T) {
 
 	assert.NoError(t, os.RemoveAll(targetDir))
 }
+
+func TestValidateUrl(t *testing.T) {
+	testCases := []struct {
+		name string
+		url string
+		expectedHasErr bool
+		expectedURL string
+	} {
+		{
+			name: "valid url",
+			url: "http://rinkeby.infura.io/v3",
+			expectedHasErr: false,
+			expectedURL: "http://rinkeby.infura.io/v3",
+		},
+		{
+			name: "without scheme",
+			url: "rinkeby.infura.io/v3/",
+			expectedHasErr: false,
+			expectedURL: "https://rinkeby.infura.io/v3/",
+		},
+		{
+			name: "not allowed scheme",
+			url: "ftp://rinkeby.infura.io/v3/",
+			expectedHasErr: true,
+			expectedURL: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			url, err := validateURL(testCase.url)
+			if testCase.expectedHasErr {
+				assert.NotNil(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectedURL, url)
+		})
+	}
+}


### PR DESCRIPTION
> Hello 👋 , this is my first PR in go-centrifuge project. I picked issue #1204 which is labeled as the good first issue and tried to work it out.
> As described in the issue, etherNodeURL needs a prefix and by default should be set to https. The validateURL adds the prefix if necessary and checks if the schema is either http or https.

Forked the existing pr to bring it up to speed

Closes #1204