### PR TITLE
p2p: Do not return error if no signatures are provided

### DIFF
--- a/p2p/client.go
+++ b/p2p/client.go
@@ -420,9 +420,9 @@ func (s *p2pPeer) validateSignatureResp(
 	header *p2ppb.Header,
 	resp *p2ppb.SignatureResponse,
 ) error {
-	if resp.GetSignatures() == nil {
-		return errors.New("no signatures were provided")
-	}
+	// NOTE: In order to ensure that anchoring can happen regardless of having received signatures or not,
+	// as per the documentation found on https://docs.centrifuge.io/build/p2p-node/#no-collaborator-signatures-required-to-anchor,
+	// this function should not error out if no signatures are provided.
 
 	compatible := version.CheckVersion(header.NodeVersion)
 	if !compatible {

--- a/p2p/client_test.go
+++ b/p2p/client_test.go
@@ -2988,6 +2988,10 @@ func TestPeer_Client_validateSignatureResp_NoSignatures(t *testing.T) {
 
 	documentMock := documents.NewDocumentMock(t)
 
+	documentMock.On("CalculateSigningRoot").
+		Return(utils.RandomSlice(32), nil).
+		Once()
+
 	receiver, err := testingcommons.GetRandomAccountID()
 	assert.NoError(t, err)
 
@@ -2996,7 +3000,7 @@ func TestPeer_Client_validateSignatureResp_NoSignatures(t *testing.T) {
 	resp := &p2ppb.SignatureResponse{}
 
 	err = peer.validateSignatureResp(documentMock, receiver, header, resp)
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 }
 
 func TestPeer_Client_validateSignatureResp_InvalidVersion(t *testing.T) {


### PR DESCRIPTION
This change is required in order to reflect the behavior mentioned in our documentation - https://docs.centrifuge.io/build/p2p-node/#no-collaborator-signatures-required-to-anchor